### PR TITLE
✨ Refresh Token 구현

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
@@ -36,6 +36,13 @@ public class UserController {
         return ResponseEntity.ok(reissueToken);
     }
 
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자의 Refresh Token을 삭제하여 로그아웃합니다.")
+    public ResponseEntity<Void> logout() {
+        userService.logout();
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/join/admin")
     @Operation(summary = "관리자 회원가입 API")
     public SuccessResponse<String> adminJoinProcess(

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +21,12 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인 API", description = "이메일과 비밀번호로 로그인 후 JWT 토큰을 헤더에 담아 반환합니다.")
+    public ResponseEntity<Void> login(@RequestBody UserRequestDTO.Login request) {
+        return ResponseEntity.ok().build();
+    }
 
     @PostMapping("/join/admin")
     @Operation(summary = "관리자 회원가입 API")

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
@@ -28,6 +28,14 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/reissue")
+    @Operation(summary = "Access Token 재발급", description = "Refresh Token을 이용해 Access Token을 재발급합니다.")
+    public ResponseEntity<UserResponseDTO.ReissueToken> reissue(@RequestBody UserRequestDTO.Reissue request) {
+        String newAccessToken = userService.reissueAccessToken(request.refreshToken());
+        UserResponseDTO.ReissueToken reissueToken = new UserResponseDTO.ReissueToken(newAccessToken);
+        return ResponseEntity.ok(reissueToken);
+    }
+
     @PostMapping("/join/admin")
     @Operation(summary = "관리자 회원가입 API")
     public SuccessResponse<String> adminJoinProcess(

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
@@ -24,16 +24,21 @@ public class UserController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인 API", description = "이메일과 비밀번호로 로그인 후 JWT 토큰을 헤더에 담아 반환합니다.")
-    public ResponseEntity<Void> login(@RequestBody UserRequestDTO.Login request) {
+    public ResponseEntity<Void> login(
+            @RequestBody UserRequestDTO.Login request
+    ) {
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/reissue")
     @Operation(summary = "Access Token 재발급", description = "Refresh Token을 이용해 Access Token을 재발급합니다.")
-    public ResponseEntity<UserResponseDTO.ReissueToken> reissue(@RequestBody UserRequestDTO.Reissue request) {
-        String newAccessToken = userService.reissueAccessToken(request.refreshToken());
-        UserResponseDTO.ReissueToken reissueToken = new UserResponseDTO.ReissueToken(newAccessToken);
-        return ResponseEntity.ok(reissueToken);
+    public ResponseEntity<Void> reissue(
+            @RequestHeader("Refresh-Token") String refreshToken
+    ) {
+        String newAccessToken = userService.reissueAccessToken(refreshToken);
+        return ResponseEntity.ok()
+                .header("Authorization", "Bearer " + newAccessToken)
+                .build();
     }
 
     @PostMapping("/logout")

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserRequestDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserRequestDTO.java
@@ -19,6 +19,12 @@ public class UserRequestDTO {
             @Schema(description = "비밀번호", example = "Abc123!@") String password
     ) {}
 
+    @Schema(description = "Access Token 재발급 요청 DTO")
+    public record Reissue(
+            @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1...")
+            String refreshToken
+    ) {}
+
     @Schema(description = "관리자 회원가입 요청 DTO")
     public record AdminJoin(
             @Schema(description = "이름", example = "홍길동")

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserRequestDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserRequestDTO.java
@@ -19,12 +19,6 @@ public class UserRequestDTO {
             @Schema(description = "비밀번호", example = "Abc123!@") String password
     ) {}
 
-    @Schema(description = "Access Token 재발급 요청 DTO")
-    public record Reissue(
-            @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1...")
-            String refreshToken
-    ) {}
-
     @Schema(description = "관리자 회원가입 요청 DTO")
     public record AdminJoin(
             @Schema(description = "이름", example = "홍길동")

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserRequestDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserRequestDTO.java
@@ -13,11 +13,10 @@ import java.time.LocalDate;
 @Schema(description = "회원 관련 요청 DTO")
 public class UserRequestDTO {
 
-    @Schema(description = "회원가입 요청 DTO")
-    public record Join (
-            @Schema(description = "이메일", example = "test@gmail.com") String email,
-            @Schema(description = "비밀번호", example = "1234") String password,
-            @Schema(description = "권한", example = "USER") Role role
+    @Schema(description = "로그인 요청 DTO")
+    public record Login (
+            @Schema(description = "이메일", example = "user@example.com") String email,
+            @Schema(description = "비밀번호", example = "Abc123!@") String password
     ) {}
 
     @Schema(description = "관리자 회원가입 요청 DTO")

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
@@ -7,21 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "사용자 관련 응답 DTO")
 public class UserResponseDTO {
 
-    @Schema(description = "로그인 성공 시 발급된 토큰 응답 DTO")
-    public record Login(
-            @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIs...")
-            String accessToken,
-
-            @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIs...")
-            String refreshToken
-    ) {}
-
-    @Schema(description = "Access Token 재발급 응답 DTO")
-    public record ReissueToken(
-            @Schema(description = "새로운 Access Token", example = "eyJhbGciOiJIUzI1...")
-            String accessToken
-    ) {}
-
     @Schema(description = "사용자 요약 정보 응답 DTO")
     public record Summary(
             @Schema(description = "사용자 ID") Long userId,

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
@@ -7,6 +7,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "사용자 관련 응답 DTO")
 public class UserResponseDTO {
 
+    @Schema(description = "로그인 성공 시 발급된 토큰 응답 DTO")
+    public record Login(
+            @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIs...")
+            String accessToken,
+
+            @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIs...")
+            String refreshToken
+    ) {}
+
     @Schema(description = "사용자 요약 정보 응답 DTO")
     public record Summary(
             @Schema(description = "사용자 ID") Long userId,

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
@@ -16,6 +16,12 @@ public class UserResponseDTO {
             String refreshToken
     ) {}
 
+    @Schema(description = "Access Token 재발급 응답 DTO")
+    public record ReissueToken(
+            @Schema(description = "새로운 Access Token", example = "eyJhbGciOiJIUzI1...")
+            String accessToken
+    ) {}
+
     @Schema(description = "사용자 요약 정보 응답 DTO")
     public record Summary(
             @Schema(description = "사용자 ID") Long userId,

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserService.java
@@ -12,4 +12,5 @@ public interface UserService {
     void requestPhoneVerification(String phoneNumber);
     void confirmPhoneVerification(String phoneNumber, String inputCode);
     String reissueAccessToken(String refreshToken);
+    void logout();
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserService.java
@@ -11,4 +11,5 @@ public interface UserService {
     boolean isEmailDuplicated(String email);
     void requestPhoneVerification(String phoneNumber);
     void confirmPhoneVerification(String phoneNumber, String inputCode);
+    String reissueAccessToken(String refreshToken);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserServiceImpl.java
@@ -7,6 +7,7 @@ import KUSITMS.WITHUS.domain.user.user.entity.User;
 import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
 import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
 import KUSITMS.WITHUS.domain.user.userOrganization.entity.UserOrganization;
+import KUSITMS.WITHUS.global.auth.dto.CustomUserDetails;
 import KUSITMS.WITHUS.global.auth.jwt.util.JwtUtil;
 import KUSITMS.WITHUS.global.common.enumerate.Gender;
 import KUSITMS.WITHUS.global.exception.CustomException;
@@ -15,6 +16,8 @@ import KUSITMS.WITHUS.global.infra.sms.SmsSender;
 import KUSITMS.WITHUS.global.util.redis.RefreshTokenCacheUtil;
 import KUSITMS.WITHUS.global.util.redis.VerificationCacheUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,11 +40,31 @@ public class UserServiceImpl implements UserService {
     private final RefreshTokenCacheUtil refreshTokenCacheUtil;
 
     /**
+     * 로그아웃
+     * @throws CustomException 인증 정보가 없거나 유효하지 않은 경우 예외를 발생시킵니다.
+     */
+    @Override
+    public void logout() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 인증 정보가 없거나 인증이 안 된 경우 (토큰이 없을 때 포함)
+        if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String email = userDetails.getUsername();
+
+        refreshTokenCacheUtil.deleteRefreshToken(email);
+    }
+
+    /**
      * Refresh Token을 검증하고, 유효한 경우 새로운 Access Token을 발급합니다.
      * @param refreshToken 클라이언트로부터 전달받은 Refresh Token
      * @return 새로 발급된 Access Token
      * @throws CustomException Refresh Token이 만료되었거나 유효하지 않은 경우 예외를 발생시킵니다.
      */
+    @Override
     public String reissueAccessToken(String refreshToken) {
         if (jwtUtil.isExpired(refreshToken)) {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_INVALID);
@@ -61,7 +84,7 @@ public class UserServiceImpl implements UserService {
     }
 
     /**
-     * 관리자 회원가입 프로세스
+     * 관리자 회원가입
      * @param request 관리자의 이름, 조직명, 이메일, 비밀번호, 전화번호를 입력받습니다.
      * @throws CustomException 이메일이 이미 존재하거나 전화번호 인증이 완료되지 않은 경우 예외를 발생시킵니다.
      */
@@ -112,7 +135,7 @@ public class UserServiceImpl implements UserService {
     }
 
     /**
-     * 사용자 회원가입 프로세스
+     * 사용자 회원가입
      * @param request 사용자의 이름, 생년월일, 성별, 조직 ID, 이메일, 비밀번호, 전화번호를 입력받습니다.
      * @throws CustomException 이메일이 이미 존재하거나 전화번호 인증이 완료되지 않은 경우 예외를 발생시킵니다.
      */

--- a/src/main/java/KUSITMS/WITHUS/global/auth/jwt/JwtFilter.java
+++ b/src/main/java/KUSITMS/WITHUS/global/auth/jwt/JwtFilter.java
@@ -52,7 +52,7 @@ public class JwtFilter extends OncePerRequestFilter {
         if (jwtUtil.isExpired(token)) {
 
             System.out.println("token expired");
-            filterChain.doFilter(request, response);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
             //조건이 해당되면 메소드 종료 (필수)
             return;

--- a/src/main/java/KUSITMS/WITHUS/global/auth/jwt/LoginFilter.java
+++ b/src/main/java/KUSITMS/WITHUS/global/auth/jwt/LoginFilter.java
@@ -80,12 +80,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         refreshTokenCacheUtil.saveRefreshToken(email, refreshToken, refreshTokenTTL);
 
         // 응답으로 AccessToken + RefreshToken 내려주기 (JSON Body로)
-        response.setContentType("application/json");
-        response.setCharacterEncoding("utf-8");
-
-        UserResponseDTO.Login tokenResponse = new UserResponseDTO.Login(accessToken, refreshToken);
-        ObjectMapper objectMapper = new ObjectMapper();
-        response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        response.setHeader("Refresh-Token", refreshToken);
 
     }
 

--- a/src/main/java/KUSITMS/WITHUS/global/auth/jwt/util/JwtUtil.java
+++ b/src/main/java/KUSITMS/WITHUS/global/auth/jwt/util/JwtUtil.java
@@ -38,6 +38,16 @@ public class JwtUtil {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration().before(new Date());
     }
 
+    public String createAccessToken(String email, String role) {
+        long accessTokenExpireMs = 1000L * 60 * 10; // 10분
+        return createJwt(email, role, accessTokenExpireMs);
+    }
+
+    public String createRefreshToken(String email, String role) {
+        long refreshTokenExpireMs = 1000L * 60 * 60 * 24 * 7; // 7일
+        return createJwt(email, role, refreshTokenExpireMs);
+    }
+
     public String createJwt(String email, String role, Long expiredMs) {
 
         Claims claims = Jwts.claims();

--- a/src/main/java/KUSITMS/WITHUS/global/config/CorsConfig.java
+++ b/src/main/java/KUSITMS/WITHUS/global/config/CorsConfig.java
@@ -22,7 +22,7 @@ public class CorsConfig {
         config.addAllowedMethod("*");
         config.addAllowedHeader("*");
         config.addExposedHeader("Authorization");
-        config.addExposedHeader("refresh-token");
+        config.addExposedHeader("Refresh-Token");
 
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);

--- a/src/main/java/KUSITMS/WITHUS/global/config/SecurityConfig.java
+++ b/src/main/java/KUSITMS/WITHUS/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package KUSITMS.WITHUS.global.config;
 import KUSITMS.WITHUS.global.auth.jwt.JwtFilter;
 import KUSITMS.WITHUS.global.auth.jwt.LoginFilter;
 import KUSITMS.WITHUS.global.auth.jwt.util.JwtUtil;
+import KUSITMS.WITHUS.global.util.redis.RefreshTokenCacheUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,6 +33,7 @@ public class SecurityConfig {
 
     //AuthenticationManager가 인자로 받을 AuthenticationConfiguraion 객체 생성자 주입
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final RefreshTokenCacheUtil refreshTokenCacheUtil;
     //JWTUtil 주입
     private final JwtUtil jwtUtil;
 
@@ -51,7 +53,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        LoginFilter loginFilter = new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil);
+        LoginFilter loginFilter = new LoginFilter(authenticationManager(authenticationConfiguration), refreshTokenCacheUtil, jwtUtil);
         loginFilter.setFilterProcessesUrl("/api/v1/auth/login");
 
         http

--- a/src/main/java/KUSITMS/WITHUS/global/util/redis/RefreshTokenCacheUtil.java
+++ b/src/main/java/KUSITMS/WITHUS/global/util/redis/RefreshTokenCacheUtil.java
@@ -1,0 +1,32 @@
+package KUSITMS.WITHUS.global.util.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCacheUtil {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+
+    // RefreshToken 저장
+    public void saveRefreshToken(String email, String refreshToken, Duration ttl) {
+        String key = REFRESH_TOKEN_PREFIX + email;
+        redisTemplate.opsForValue().set(key, refreshToken, ttl);
+    }
+
+    // RefreshToken 조회
+    public String getRefreshToken(String email) {
+        return redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + email);
+    }
+
+    // RefreshToken 삭제 (로그아웃용)
+    public void deleteRefreshToken(String email) {
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + email);
+    }
+}


### PR DESCRIPTION
### ✨ Related Issue

- #6 
- #24 

---

### 📌 Task Details
- [x] swagger login 엔드포인트 설정
- [x] LoginFilter 디폴트 요청 타입 formdata -> JSON 으로 수정
- [x] 로그인 시 access token, refresh token 발급
- [x] refresh 토큰 재발급 기능 구현
- [x] 로그아웃 기능 구현

---

### 💬 Review Requirements (Optional)

로그인은 auth에, 회원가입 및 여러 인증은 user에 두는 게 좋을지, 지금 그대로 둬도 괜찮을지 고민입니다..!
현재 모두 /api/v1/auth 엔드포인트를 기본으로 쓰긴 해서 다 user 도메인에 몰아 둔 상태이긴 합니다!
그 외에 피드백 주실 부분 편하게 주시면 감사하겠습니다 😃
