### PR TITLE
🐛 조직관리 2차 수정

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/controller/OrganizationRoleController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/controller/OrganizationRoleController.java
@@ -50,14 +50,14 @@ public class OrganizationRoleController {
         return SuccessResponse.ok(response);
     }
 
-    @PostMapping("/{organizationId}/roles/{roleId}/assign-users")
+    @PutMapping("/{organizationId}/roles/{roleId}/assign-users")
     @Operation(summary = "역할에 사용자 일괄 추가", description = "특정 역할에 여러 명의 운영진을 한 번에 추가합니다.")
     public SuccessResponse<List<OrganizationRoleResponseDTO.DetailForUser>> assignUsersToRole(
             @PathVariable Long organizationId,
             @PathVariable Long roleId,
             @RequestBody @Valid OrganizationRoleRequestDTO.AssignUsersToRole request
     ) {
-        List<OrganizationRoleResponseDTO.DetailForUser> response = organizationRoleService.assignUsersToRole(organizationId, roleId, request.userIds());
+        List<OrganizationRoleResponseDTO.DetailForUser> response = organizationRoleService.updateUsersOfRole(organizationId, roleId, request.userIds());
         return SuccessResponse.ok(response);
     }
 

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/controller/OrganizationRoleController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/controller/OrganizationRoleController.java
@@ -61,4 +61,14 @@ public class OrganizationRoleController {
         return SuccessResponse.ok(response);
     }
 
+    @PatchMapping("/{organizationId}/roles/{roleId}")
+    @Operation(summary = "조직 역할 수정", description = "조직 내 특정 역할의 이름과 색상을 수정합니다.")
+    public SuccessResponse<String> updateRole(
+            @PathVariable Long organizationId,
+            @PathVariable Long roleId,
+            @RequestBody @Valid OrganizationRoleRequestDTO.Update request
+    ) {
+        organizationRoleService.updateRole(organizationId, roleId, request.name(), request.color());
+        return SuccessResponse.ok("조직 내 역할 수정에 성공했습니다.");
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/dto/OrganizationRoleRequestDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/dto/OrganizationRoleRequestDTO.java
@@ -34,4 +34,12 @@ public class OrganizationRoleRequestDTO {
             @NotEmpty List<Long> userIds
     ) {}
 
+    @Schema(description = "조직의 역할 수정 요청 DTO")
+    public record Update(
+            @Schema(description = "수정할 역할 이름", example = "부학회장")
+            @NotBlank String name,
+
+            @Schema(description = "수정할 색상", example = "green")
+            @NotBlank String color
+    ) {}
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/entity/OrganizationRole.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/entity/OrganizationRole.java
@@ -35,6 +35,11 @@ public class OrganizationRole {
     @OneToMany(mappedBy = "organizationRole", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserOrganizationRole> userOrganizationRoles = new ArrayList<>();
 
+    public void update(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
+
     public void associateOrganization(Organization organization) {
         this.organization = organization;
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/repository/OrganizationRoleRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/repository/OrganizationRoleRepository.java
@@ -10,4 +10,5 @@ public interface OrganizationRoleRepository {
     boolean existsByOrganizationIdAndName(Long organizationId, String name);
     List<OrganizationRole> findAllById(List<Long> roleIds);
     List<OrganizationRole> findByOrganizationIdAndKeyword(Long organizationId, String keyword);
+    boolean existsByOrganizationIdAndNameExceptId(Long organizationId, String name, Long excludedId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/repository/OrganizationRoleRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/repository/OrganizationRoleRepositoryImpl.java
@@ -54,6 +54,19 @@ public class OrganizationRoleRepositoryImpl implements OrganizationRoleRepositor
                 .fetch();
     }
 
+    @Override
+    public boolean existsByOrganizationIdAndNameExceptId(Long organizationId, String name, Long excludedId) {
+        return queryFactory
+                .selectOne()
+                .from(organizationRole)
+                .where(
+                        organizationRole.organization.id.eq(organizationId),
+                        organizationRole.name.eq(name),
+                        organizationRole.id.ne(excludedId)
+                )
+                .fetchFirst() != null;
+    }
+
     private BooleanExpression keywordCondition(String keyword) {
         if (keyword == null || keyword.isBlank()) {
             return null;

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleService.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 public interface OrganizationRoleService {
     List<OrganizationRoleResponseDTO.DetailForUser> assignRoleToUser(Long organizationId, Long userId, List<Long> roleIds);
+    List<OrganizationRoleResponseDTO.DetailForUser> updateUsersOfRole(Long organizationId, Long roleId, List<Long> newUserIds);
     OrganizationRoleResponseDTO.Detail createRole(Long organizationId, String name, String color);
     OrganizationRoleResponseDTO.DetailForOrganization getOrganizationRoles(Long organizationId, String keyword);
-    List<OrganizationRoleResponseDTO.DetailForUser> assignUsersToRole(Long organizationId, Long roleId, List<Long> userIds);
     void updateRole(Long organizationId, Long roleId, String name, String color);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleService.java
@@ -9,4 +9,5 @@ public interface OrganizationRoleService {
     OrganizationRoleResponseDTO.Detail createRole(Long organizationId, String name, String color);
     OrganizationRoleResponseDTO.DetailForOrganization getOrganizationRoles(Long organizationId, String keyword);
     List<OrganizationRoleResponseDTO.DetailForUser> assignUsersToRole(Long organizationId, Long roleId, List<Long> userIds);
+    void updateRole(Long organizationId, Long roleId, String name, String color);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
@@ -15,8 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -102,7 +102,6 @@ public class OrganizationRoleServiceImpl implements OrganizationRoleService {
                 .map(OrganizationRoleResponseDTO.RoleDetail::from)
                 .toList();
 
-
         return OrganizationRoleResponseDTO.DetailForOrganization.from(roleDetails);
     }
 
@@ -110,34 +109,74 @@ public class OrganizationRoleServiceImpl implements OrganizationRoleService {
      * 특정 역할에 운영진 일괄 추가
      * @param organizationId 역할이 속한 조직 ID
      * @param roleId 추가할 역할 ID
-     * @param userIds 추가될 사용자 ID 리스트
+     * @param newUserIds 추가될 사용자 ID 리스트
      * @return 추가된 정보 반환
      */
     @Override
     @Transactional
-    public List<OrganizationRoleResponseDTO.DetailForUser> assignUsersToRole(Long organizationId, Long roleId, List<Long> userIds) {
+    public List<OrganizationRoleResponseDTO.DetailForUser> updateUsersOfRole(Long organizationId, Long roleId, List<Long> newUserIds) {
         OrganizationRole role = organizationRoleRepository.getById(roleId);
 
-        List<User> users = userRepository.findAllById(userIds);
-        List<OrganizationRoleResponseDTO.DetailForUser> result = new ArrayList<>();
-
-        for (User user : users) {
-            boolean alreadyAssigned = user.getUserOrganizationRoles().stream()
-                    .anyMatch(r -> r.getOrganizationRole().getId().equals(roleId));
-
-            if (alreadyAssigned) continue;
-
-            UserOrganizationRole userOrgRole = UserOrganizationRole.assign(user, role);
-
-            user.addUserOrganizationRole(userOrgRole);
-            role.addUserOrganizationRole(userOrgRole);
-
-            userOrganizationRoleRepository.save(userOrgRole);
-
-            result.add(OrganizationRoleResponseDTO.DetailForUser.from(userOrgRole));
+        if (!role.getOrganization().getId().equals(organizationId)) {
+            throw new CustomException(ErrorCode.ORGANIZATION_ROLE_ORG_MISMATCH);
         }
 
-        return result;
+        Set<Long> newUserIdSet = new HashSet<>(newUserIds);
+        List<UserOrganizationRole> currentAssignments = role.getUserOrganizationRoles();
+
+        // 삭제할 사용자 역할 매핑 제거
+        List<UserOrganizationRole> toRemove = currentAssignments.stream()
+                .filter(assignment -> !newUserIdSet.contains(assignment.getUser().getId()))
+                .toList();
+        userOrganizationRoleRepository.deleteAll(toRemove);
+
+        Set<Long> removedUserIds = toRemove.stream()
+                .map(assignment -> assignment.getUser().getId())
+                .collect(Collectors.toSet());
+        role.getUserOrganizationRoles().removeIf(
+                assignment -> removedUserIds.contains(assignment.getUser().getId())
+        );
+
+        // 기존 유지되는 사용자 ID 추출
+        Set<Long> existingUserIds = currentAssignments.stream()
+                .map(assignment -> assignment.getUser().getId())
+                .collect(Collectors.toSet());
+
+        // 새롭게 추가할 사용자 ID 필터링
+        List<Long> toAddUserIds = newUserIds.stream()
+                .filter(id -> !existingUserIds.contains(id))
+                .toList();
+        List<User> toAddUsers = userRepository.findAllById(toAddUserIds);
+
+        // 새로운 사용자 역할 매핑 생성
+        List<UserOrganizationRole> newAssignments = new ArrayList<>();
+        for (User user : toAddUsers) {
+            UserOrganizationRole userOrgRole = UserOrganizationRole.assign(user, role);
+            user.addUserOrganizationRole(userOrgRole);
+            role.addUserOrganizationRole(userOrgRole);
+            newAssignments.add(userOrgRole);
+        }
+
+        userOrganizationRoleRepository.saveAll(newAssignments);
+
+        // 최종 응답
+        Map<Long, OrganizationRoleResponseDTO.DetailForUser> resultMap = new LinkedHashMap<>();
+
+        currentAssignments.stream()
+                .filter(assignment -> newUserIdSet.contains(assignment.getUser().getId()))
+                .forEach(assignment -> resultMap.put(
+                        assignment.getUser().getId(),
+                        OrganizationRoleResponseDTO.DetailForUser.from(assignment)
+                ));
+
+        newAssignments.forEach(assignment ->
+                resultMap.put(
+                        assignment.getUser().getId(),
+                        OrganizationRoleResponseDTO.DetailForUser.from(assignment)
+                )
+        );
+
+        return new ArrayList<>(resultMap.values());
     }
 
     /**

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
@@ -139,4 +139,22 @@ public class OrganizationRoleServiceImpl implements OrganizationRoleService {
 
         return result;
     }
+
+    @Override
+    @Transactional
+    public void updateRole(Long organizationId, Long roleId, String name, String color) {
+        OrganizationRole role = organizationRoleRepository.getById(roleId);
+
+        if (!role.getOrganization().getId().equals(organizationId)) {
+            throw new CustomException(ErrorCode.ORGANIZATION_ROLE_ORG_MISMATCH);
+        }
+
+        boolean nameConflict = organizationRoleRepository.existsByOrganizationIdAndNameExceptId(organizationId, name, roleId);
+        if (nameConflict) {
+            throw new CustomException(ErrorCode.DUPLICATE_ORGANIZATION_ROLE_NAME);
+        }
+
+        role.update(name, color);
+    }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
@@ -140,6 +140,13 @@ public class OrganizationRoleServiceImpl implements OrganizationRoleService {
         return result;
     }
 
+    /**
+     * 역할 수정
+     * @param organizationId 수정할 역할이 속한 조직 ID
+     * @param roleId 수정할 역할 ID
+     * @param name 수정할 이름
+     * @param color 수정할 색상
+     */
     @Override
     @Transactional
     public void updateRole(Long organizationId, Long roleId, String name, String color) {

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/controller/UserController.java
@@ -59,11 +59,11 @@ public class UserController {
 
     @GetMapping("/email")
     @Operation(summary = "이메일로 사용자 단건 조회 API", description = "이메일이 정확히 일치하는 사용자를 조회합니다.")
-    public SuccessResponse<UserResponseDTO.SummaryForSearch> getUserByEmail(
+    public SuccessResponse<UserResponseDTO.SummaryForEmailSearch> getUserByEmail(
             @RequestParam("email") @Email String email
     ) {
         User user = userService.getUserByEmail(email);
-        return SuccessResponse.ok(UserResponseDTO.SummaryForSearch.from(user));
+        return SuccessResponse.ok(UserResponseDTO.SummaryForEmailSearch.from(user));
     }
 
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
@@ -28,19 +28,38 @@ public class UserResponseDTO {
         }
     }
 
-    @Schema(description = "검색 결과에 대한 사용자 요약 정보 응답 DTO")
-    public record SummaryForSearch(
+    @Schema(description = "이메일 검색 결과에 대한 사용자 요약 정보 응답 DTO")
+    public record SummaryForEmailSearch(
             @Schema(description = "사용자 ID") Long userId,
             @Schema(description = "이름") String name,
             @Schema(description = "이메일") String email,
             @Schema(description = "프로필 사진 URL") String imageUrl
     ) {
-        public static SummaryForSearch from(User user) {
-            return new SummaryForSearch(
+        public static SummaryForEmailSearch from(User user) {
+            return new SummaryForEmailSearch(
                     user.getId(),
                     user.getName(),
                     user.getEmail(),
                     user.getProfileImageUrl()
+            );
+        }
+    }
+
+    @Schema(description = "검색 결과에 대한 사용자 요약 정보 응답 DTO")
+    public record SummaryForSearch(
+            @Schema(description = "사용자 ID") Long userId,
+            @Schema(description = "이름") String name,
+            @Schema(description = "이메일") String email,
+            @Schema(description = "프로필 사진 URL") String imageUrl,
+            @Schema(description = "역할에 속해있는지 여부") boolean isAssigned
+    ) {
+        public static SummaryForSearch from(User user, boolean isAssigned) {
+            return new SummaryForSearch(
+                    user.getId(),
+                    user.getName(),
+                    user.getEmail(),
+                    user.getProfileImageUrl(),
+                    isAssigned
             );
         }
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/dto/UserResponseDTO.java
@@ -48,21 +48,21 @@ public class UserResponseDTO {
     @Schema(description = "사용자 상세 정보 응답 DTO")
     public record DetailProfile(
             @Schema(description = "사용자 ID") Long userId,
+            @Schema(description = "프로필 이미지 URL") String profileImageUrl,
             @Schema(description = "이름") String name,
-            @Schema(description = "전화번호") String phoneNumber,
             @Schema(description = "이메일") String email,
-            @Schema(description = "생년월일") @DateFormat LocalDate birthDate,
+            @Schema(description = "역할") List<OrganizationRoleResponseDTO.Detail> roles,
             @Schema(description = "성별") String gender,
-            @Schema(description = "역할") List<OrganizationRoleResponseDTO.Detail> roles
+            @Schema(description = "생년월일") @DateFormat LocalDate birthDate,
+            @Schema(description = "전화번호") String phoneNumber,
+            @Schema(description = "가입일자") @DateTimeFormat LocalDateTime createdAt
     ) {
         public static DetailProfile from(User user, Long organizationId) {
             return new DetailProfile(
                     user.getId(),
+                    user.getProfileImageUrl(),
                     user.getName(),
-                    user.getPhoneNumber(),
                     user.getEmail(),
-                    user.getBirthDate(),
-                    user.getGender().getKey(),
                     user.getUserOrganizationRoles().stream()
                             .filter(userOrganizationRole ->
                                     userOrganizationRole.getOrganizationRole()
@@ -73,7 +73,11 @@ public class UserResponseDTO {
                             .map(userOrganizationRole ->
                                     OrganizationRoleResponseDTO.Detail.from(userOrganizationRole.getOrganizationRole())
                             )
-                            .toList()
+                            .toList(),
+                    user.getGender().getKey(),
+                    user.getBirthDate(),
+                    user.getPhoneNumber(),
+                    user.getCreatedAt()
             );
         }
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/controller/UserOrganizationController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/controller/UserOrganizationController.java
@@ -53,12 +53,13 @@ public class UserOrganizationController {
     }
 
     @GetMapping("/{organizationId}/users/search")
-    @Operation(summary = "조직 운영진 전체 조회 및 검색", description = "조직 ID를 기준으로 운영진 목록을 전부 조회하고 keyword가 존재하면 검색합니다.")
+    @Operation(summary = "조직 운영진 전체 조회 및 검색", description = "조직 ID를 기준으로 운영진 목록을 전부 조회하고 keyword, 역할ID가 존재하면 검색합니다.")
     public SuccessResponse<List<UserResponseDTO.SummaryForSearch>> getAllUsersByOrganization(
             @PathVariable Long organizationId,
-            @RequestParam(required = false) String keyword
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long roleId
     ) {
-        List<UserResponseDTO.SummaryForSearch> response = organizationUserService.getAllUsersByOrganization(organizationId, keyword);
+        List<UserResponseDTO.SummaryForSearch> response = organizationUserService.getUsersWithAssignment(organizationId, keyword, roleId);
         return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/controller/UserOrganizationController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/controller/UserOrganizationController.java
@@ -24,7 +24,7 @@ public class UserOrganizationController {
 
     @GetMapping("/{organizationId}/users")
     @Operation(summary = "조직 사용자 목록 조회", description = "조직에 소속된 운영진 목록을 조회합니다.")
-    public SuccessResponse<Page<UserResponseDTO.DetailForOrganization>> getMembers(
+    public SuccessResponse<Page<UserResponseDTO.DetailProfile>> getMembers(
             @PathVariable Long organizationId,
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "10") int size

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/repository/UserOrganizationRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/repository/UserOrganizationRepository.java
@@ -13,5 +13,5 @@ public interface UserOrganizationRepository {
     Page<User> findByOrganizationId(Long organizationId, Pageable pageable);
     List<UserOrganization> findAllByOrganizationIdAndUserIdIn(Long organizationId, List<Long> userIds);
     void deleteAllInBatch(List<UserOrganization> userOrganizations);
-    List<User> findManagersByOrganizationId(Long organizationId, String keyword);
+    List<User> findUsersByOrganizationAndKeyword(Long orgId, String keyword);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/repository/UserOrganizationRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/repository/UserOrganizationRepositoryImpl.java
@@ -3,7 +3,6 @@ package KUSITMS.WITHUS.domain.user.userOrganization.repository;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
 import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
 import KUSITMS.WITHUS.domain.user.userOrganization.entity.UserOrganization;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,6 +15,7 @@ import java.util.Optional;
 
 import static KUSITMS.WITHUS.domain.user.user.entity.QUser.user;
 import static KUSITMS.WITHUS.domain.user.userOrganization.entity.QUserOrganization.userOrganization;
+import static KUSITMS.WITHUS.domain.user.userOrganizationRole.entity.QUserOrganizationRole.userOrganizationRole;
 
 @Repository
 @RequiredArgsConstructor
@@ -89,23 +89,18 @@ public class UserOrganizationRepositoryImpl implements UserOrganizationRepositor
     }
 
     @Override
-    public List<User> findManagersByOrganizationId(Long organizationId, String keyword) {
+    public List<User> findUsersByOrganizationAndKeyword(Long orgId, String keyword) {
         return queryFactory
                 .select(user)
-                .from(userOrganization)
-                .join(userOrganization.user, user)
+                .from(userOrganizationRole)
+                .join(userOrganizationRole.user, user)
                 .where(
-                        userOrganization.organization.id.eq(organizationId),
-                        user.role.eq(Role.USER),
-                        keywordCondition(keyword)
+                        userOrganizationRole.organizationRole.organization.id.eq(orgId),
+                        keyword != null ? user.name.containsIgnoreCase(keyword).or(user.email.containsIgnoreCase(keyword)) : null
                 )
+                .distinct()
                 .fetch();
     }
 
-    private BooleanExpression keywordCondition(String keyword) {
-        if (keyword == null || keyword.isBlank()) {
-            return null;
-        }
-        return user.name.containsIgnoreCase(keyword);
-    }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/service/UserOrganizationService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/service/UserOrganizationService.java
@@ -10,5 +10,5 @@ public interface UserOrganizationService {
     Page<UserResponseDTO.DetailProfile> getUsers(Long organizationId, int page, int size);
     List<UserOrganizationResponseDTO.Detail> addUserToOrganization(Long organizationId, List<Long> userIds);
     void removeUsers(Long organizationId, List<Long> userIds);
-    List<UserResponseDTO.SummaryForSearch> getAllUsersByOrganization(Long organizationId, String keyword);
+    List<UserResponseDTO.SummaryForSearch> getUsersWithAssignment(Long organizationId, String keyword, Long roleId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/service/UserOrganizationService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/service/UserOrganizationService.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 
 public interface UserOrganizationService {
-    Page<UserResponseDTO.DetailForOrganization> getUsers(Long organizationId, int page, int size);
+    Page<UserResponseDTO.DetailProfile> getUsers(Long organizationId, int page, int size);
     List<UserOrganizationResponseDTO.Detail> addUserToOrganization(Long organizationId, List<Long> userIds);
     void removeUsers(Long organizationId, List<Long> userIds);
     List<UserResponseDTO.SummaryForSearch> getAllUsersByOrganization(Long organizationId, String keyword);

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/service/UserOrganizationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/service/UserOrganizationServiceImpl.java
@@ -97,15 +97,22 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
     }
 
     /**
-     * 조직에 속한 운영진 전체 조회, keyword가 있다면 검색
+     * 조직에 속한 운영진 전체 조회,  keyword, roleId가 있다면 검색
      * @param organizationId 조회할 조직의 ID
      * @param keyword 검색어(이름)
      * @return 조회된 유저 정보
      */
     @Override
-    public List<UserResponseDTO.SummaryForSearch> getAllUsersByOrganization(Long organizationId, String keyword) {
-        return userOrganizationRepository.findManagersByOrganizationId(organizationId, keyword).stream()
-                .map(UserResponseDTO.SummaryForSearch::from)
+    public List<UserResponseDTO.SummaryForSearch> getUsersWithAssignment(Long organizationId, String keyword, Long roleId) {
+        List<User> users = userOrganizationRepository.findUsersByOrganizationAndKeyword(organizationId, keyword);
+
+        return users.stream()
+                .map(user -> {
+                    boolean assigned = user.getUserOrganizationRoles().stream()
+                            .anyMatch(r -> r.getOrganizationRole().getId().equals(roleId));
+                    return UserResponseDTO.SummaryForSearch.from(user, assigned);
+                })
                 .toList();
     }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/service/UserOrganizationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganization/service/UserOrganizationServiceImpl.java
@@ -35,12 +35,12 @@ public class UserOrganizationServiceImpl implements UserOrganizationService {
      * @return 조회한 사용자들의 정보
      */
     @Override
-    public Page<UserResponseDTO.DetailForOrganization> getUsers(Long organizationId, int page, int size) {
+    public Page<UserResponseDTO.DetailProfile> getUsers(Long organizationId, int page, int size) {
         organizationRepository.getById(organizationId);
 
         Pageable pageable = PageRequest.of(page, size);
         return userOrganizationRepository.findByOrganizationId(organizationId, pageable)
-                .map(UserResponseDTO.DetailForOrganization::from);
+                .map(user -> UserResponseDTO.DetailProfile.from(user, organizationId));
     }
 
     /**

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepository.java
@@ -2,6 +2,10 @@ package KUSITMS.WITHUS.domain.user.userOrganizationRole.repository;
 
 import KUSITMS.WITHUS.domain.user.userOrganizationRole.entity.UserOrganizationRole;
 
+import java.util.List;
+
 public interface UserOrganizationRoleRepository {
     UserOrganizationRole save(UserOrganizationRole userOrganizationRole);
+    void deleteAll(List<UserOrganizationRole> userOrganizationRoles);
+    void saveAll(List<UserOrganizationRole> userOrganizationRoles);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepositoryImpl.java
@@ -4,6 +4,8 @@ import KUSITMS.WITHUS.domain.user.userOrganizationRole.entity.UserOrganizationRo
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class UserOrganizationRoleRepositoryImpl implements UserOrganizationRoleRepository {
@@ -13,5 +15,15 @@ public class UserOrganizationRoleRepositoryImpl implements UserOrganizationRoleR
     @Override
     public UserOrganizationRole save(UserOrganizationRole userOrganizationRole) {
         return userOrganizationRoleJpaRepository.save(userOrganizationRole);
+    }
+
+    @Override
+    public void deleteAll(List<UserOrganizationRole> userOrganizationRoles) {
+        userOrganizationRoleJpaRepository.deleteAll(userOrganizationRoles);
+    }
+
+    @Override
+    public void saveAll(List<UserOrganizationRole> userOrganizationRoles) {
+        userOrganizationRoleJpaRepository.saveAll(userOrganizationRoles);
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/global/exception/ErrorCode.java
+++ b/src/main/java/KUSITMS/WITHUS/global/exception/ErrorCode.java
@@ -107,6 +107,7 @@ public enum ErrorCode {
     ORGANIZATION_ROLE_ALREADY_EXIST("ORGANIZATION_ROLE400", "이미 추가된 역할입니다.", HttpStatus.BAD_REQUEST),
     DUPLICATE_ORGANIZATION_ROLE_NAME("ORGANIZATION_ROLE400", "이미 존재하는 역할명입니다.", HttpStatus.BAD_REQUEST),
     ORGANIZATION_ROLE_NOT_EXIST("ORGANIZATION_ROLE404", "등록되지 않은 조직 역할입니다.", HttpStatus.NOT_FOUND),
+    ORGANIZATION_ROLE_ORG_MISMATCH("ORGANIZATION_ROLE403", "해당 역할은 해당 조직에 속해 있지 않습니다.", HttpStatus.FORBIDDEN),
 
     // Verification
     VERIFICATION_EXPIRED("VERIFICATION404", "인증 코드가 만료되었습니다.", HttpStatus.NOT_FOUND),


### PR DESCRIPTION
### ✨ Related Issue
- #64 
---

### 📌 Task Details
- [x] 역할 수정 API 추가
- [x] 응답 DTO에 필드 추가
- [x] 역할에 운영진 추가 API 수정 - 새로운 유저 리스트 보내면 그 유저들만 역할에 반영되도록
- [x] 운영진 검색 조건에 역할 추가
- [x] 검색시 모든 운영진 조회. boolean 값으로 해당 역할에 속했는지 안 속했는지 구분

---

### 💬 Review Requirements (Optional)
- 이번에도 수정하다보니 복잡성이 늘어나서 코드가 깔끔하지 않을 수도 있는데 더 간단한 접근법이 있다면 피드백 주세요! 
