### PR TITLE
🐛 면접 관리 5차 수정

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/controller/InterviewQuestionController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/controller/InterviewQuestionController.java
@@ -31,4 +31,17 @@ public class InterviewQuestionController {
         InterviewQuestion interviewQuestion = interviewQuestionService.addQuestionToApplication(applicationId, currentUser.getId(), request.content());
         return SuccessResponse.ok(InterviewQuestionResponseDTO.Create.from(interviewQuestion));
     }
+
+    @PatchMapping("/{questionId}")
+    @Operation(summary = "면접 질문 수정", description = "기존 면접 질문의 내용을 수정합니다.")
+    public SuccessResponse<InterviewQuestionResponseDTO.Detail> updateQuestion(
+            @PathVariable Long applicationId,
+            @PathVariable Long questionId,
+            @CurrentUser User currentUser,
+            @RequestBody @Valid InterviewQuestionRequestDTO.Update request
+    ) {
+        InterviewQuestion updated = interviewQuestionService.updateQuestion(questionId, currentUser.getId(), request.content());
+        return SuccessResponse.ok(InterviewQuestionResponseDTO.Detail.from(updated));
+    }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/dto/InterviewQuestionRequestDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/dto/InterviewQuestionRequestDTO.java
@@ -9,4 +9,9 @@ public class InterviewQuestionRequestDTO {
     public record Create(
             @Schema(description = "면접질문 내용", example = "지원동기가 무엇인가요?") String content
     ) {}
+
+    @Schema(description = "면접질문 수정 요청")
+    public record Update(
+            @Schema(description = "면접질문 내용", example = "다른 지원동기가 무엇인가요?") String content
+    ) {}
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/entity/InterviewQuestion.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/entity/InterviewQuestion.java
@@ -34,7 +34,7 @@ public class InterviewQuestion extends BaseEntity {
         this.application = application;
     }
 
-    public void associateUser(User user) {
-        this.user = user;
+    public void updateContent(String content) {
+        this.content = content;
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/repository/InterviewQuestionRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/repository/InterviewQuestionRepository.java
@@ -4,4 +4,5 @@ import KUSITMS.WITHUS.domain.application.interviewQuestion.entity.InterviewQuest
 
 public interface InterviewQuestionRepository {
     InterviewQuestion save(InterviewQuestion interviewQuestion);
+    InterviewQuestion getById(Long questionId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/repository/InterviewQuestionRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/repository/InterviewQuestionRepositoryImpl.java
@@ -1,6 +1,8 @@
 package KUSITMS.WITHUS.domain.application.interviewQuestion.repository;
 
 import KUSITMS.WITHUS.domain.application.interviewQuestion.entity.InterviewQuestion;
+import KUSITMS.WITHUS.global.exception.CustomException;
+import KUSITMS.WITHUS.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +15,11 @@ public class InterviewQuestionRepositoryImpl implements InterviewQuestionReposit
     @Override
     public InterviewQuestion save(InterviewQuestion interviewQuestion) {
         return interviewQuestionJpaRepository.save(interviewQuestion);
+    }
+
+    @Override
+    public InterviewQuestion getById(Long questionId) {
+        return interviewQuestionJpaRepository.findById(questionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INTERVIEW_QUESTION_NOT_EXIST));
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/service/InterviewQuestionService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/service/InterviewQuestionService.java
@@ -4,4 +4,5 @@ import KUSITMS.WITHUS.domain.application.interviewQuestion.entity.InterviewQuest
 
 public interface InterviewQuestionService {
     InterviewQuestion addQuestionToApplication(Long applicationId, Long userId, String content);
+    InterviewQuestion updateQuestion(Long questionId, Long id, String content);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/service/InterviewQuestionServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/interviewQuestion/service/InterviewQuestionServiceImpl.java
@@ -6,6 +6,8 @@ import KUSITMS.WITHUS.domain.application.interviewQuestion.entity.InterviewQuest
 import KUSITMS.WITHUS.domain.application.interviewQuestion.repository.InterviewQuestionRepository;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
 import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import KUSITMS.WITHUS.global.exception.CustomException;
+import KUSITMS.WITHUS.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +35,20 @@ public class InterviewQuestionServiceImpl implements InterviewQuestionService {
 
         interviewQuestionRepository.save(question);
         application.addInterviewQuestion(question);
+
+        return question;
+    }
+
+    @Override
+    @Transactional
+    public InterviewQuestion updateQuestion(Long questionId, Long id, String content) {
+        InterviewQuestion question = interviewQuestionRepository.getById(questionId);
+
+        if (!question.getUser().getId().equals(id)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        question.updateContent(content);
 
         return question;
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/controller/InterviewController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/controller/InterviewController.java
@@ -1,5 +1,6 @@
 package KUSITMS.WITHUS.domain.interview.interview.controller;
 
+import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewScheduleDTO;
 import KUSITMS.WITHUS.domain.interview.interview.service.InterviewSchedulerService;
 import KUSITMS.WITHUS.domain.interview.interview.service.InterviewService;
@@ -64,4 +65,10 @@ public class InterviewController {
         return SuccessResponse.ok(interviewService.getMyOrganizationInterviews(user));
     }
 
+    @GetMapping("/{interviewId}/config")
+    @Operation(summary = "면접 구성 조회", description = "면접실 이름 배열, 면접관 수, 지원자 수, 안내자 수를 반환합니다.")
+    public SuccessResponse<InterviewResponseDTO.Config> getInterviewConfig(@PathVariable Long interviewId) {
+        InterviewResponseDTO.Config config = interviewService.getInterviewConfig(interviewId);
+        return SuccessResponse.ok(config);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/dto/InterviewResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/dto/InterviewResponseDTO.java
@@ -1,0 +1,27 @@
+package KUSITMS.WITHUS.domain.interview.interview.dto;
+
+import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "면접 관련 응답 DTO")
+public class InterviewResponseDTO {
+
+    @Schema(description = "면접 구성 응답 DTO")
+    public record Config(
+            @Schema(description = "면접실 이름 배열") List<String> roomNames,
+            @Schema(description = "면접관 수") Integer interviewerCount,
+            @Schema(description = "지원자 수") Integer applicantCount,
+            @Schema(description = "안내자 수") Integer assistantCount
+    ) {
+        public static Config from(Interview interview, Integer interviewerCount, Integer applicantCount, Integer assistantCount) {
+            return new Config(
+                    interview.getRoomNames(),
+                    interviewerCount,
+                    applicantCount,
+                    assistantCount
+            );
+        }
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/entity/Interview.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/entity/Interview.java
@@ -27,6 +27,12 @@ public class Interview extends BaseEntity {
     @Column(name = "ROOM_COUNT", nullable = false)
     private int roomCount;
 
+    @Builder.Default
+    @ElementCollection
+    @CollectionTable(name = "INTERVIEW_ROOM_NAMES", joinColumns = @JoinColumn(name = "interview_id"))
+    @Column(name = "ROOM_NAME")
+    private List<String> roomNames = new ArrayList<>();
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "RECRUITMENT_ID", nullable = false)
     private Recruitment recruitment;
@@ -50,5 +56,10 @@ public class Interview extends BaseEntity {
 
     public void setRoomCount(int roomCount) {
         this.roomCount = roomCount;
+    }
+
+    public void setRoomNames(List<String> names) {
+        this.roomNames.clear();
+        this.roomNames.addAll(names);
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/entity/Interview.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/entity/Interview.java
@@ -24,6 +24,15 @@ public class Interview extends BaseEntity {
     @Column(name = "INTERVIEW_ID")
     private Long id;
 
+    @Column(name = "INTERVIEWER_PER_SLOT")
+    private Integer interviewerPerSlot;
+
+    @Column(name = "APPLICANT_PER_SLOT")
+    private Integer applicantPerSlot;
+
+    @Column(name = "ASSISTANT_PER_SLOT")
+    private Integer assistantPerSlot;
+
     @Column(name = "ROOM_COUNT", nullable = false)
     private int roomCount;
 
@@ -54,7 +63,10 @@ public class Interview extends BaseEntity {
         availability.associateInterview(this);
     }
 
-    public void setRoomCount(int roomCount) {
+    public void setConfig(int interviewerPerSlot, int applicantPerSlot, int assistantPerSlot, int roomCount) {
+        this.interviewerPerSlot = interviewerPerSlot;
+        this.applicantPerSlot = applicantPerSlot;
+        this.assistantPerSlot = assistantPerSlot;
         this.roomCount = roomCount;
     }
 

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewSchedulerService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewSchedulerService.java
@@ -54,7 +54,7 @@ public class InterviewSchedulerService {
         List<ApplicantAvailability> availabilityList = availabilityRepository.findByApplicationIn(applicants);
         Interview interview = interviewRepository.getById(interviewId);
 
-        interview.setRoomCount(config.roomCount());
+        interview.setConfig(config.interviewerPerSlot, config.applicantPerSlot, config.assistantPerSlot, config.roomCount());
         interview.setRoomNames(config.roomNames());
 
         // 2. ID로 빠르게 찾기 위한 맵 구성
@@ -260,6 +260,7 @@ public class InterviewSchedulerService {
     public record InterviewConfig(
             int interviewerPerSlot,
             int applicantPerSlot,
+            int assistantPerSlot,
             int roomCount,
             List<String> roomNames
     ) {}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewService.java
@@ -1,5 +1,6 @@
 package KUSITMS.WITHUS.domain.interview.interview.service;
 
+import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewScheduleDTO;
 import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
@@ -10,4 +11,5 @@ public interface InterviewService {
     Long create(Long recruitmentId);
     Interview getById(Long interviewId);
     List<InterviewScheduleDTO.MyInterviewScheduleSummaryDTO> getMyOrganizationInterviews(User user);
+    InterviewResponseDTO.Config getInterviewConfig(Long interviewId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewServiceImpl.java
@@ -2,6 +2,7 @@ package KUSITMS.WITHUS.domain.interview.interview.service;
 
 import KUSITMS.WITHUS.domain.application.application.entity.Application;
 import KUSITMS.WITHUS.domain.application.application.repository.ApplicationRepository;
+import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewScheduleDTO;
 import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
 import KUSITMS.WITHUS.domain.interview.interview.repository.InterviewRepository;
@@ -82,4 +83,15 @@ public class InterviewServiceImpl implements InterviewService {
                 .toList();
     }
 
+    @Override
+    public InterviewResponseDTO.Config getInterviewConfig(Long interviewId) {
+        Interview interview = interviewRepository.getById(interviewId);
+
+        return InterviewResponseDTO.Config.from(
+                interview,
+                interview.getInterviewerPerSlot(),
+                interview.getApplicantPerSlot(),
+                interview.getAssistantPerSlot()
+        );
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/controller/TimeSlotUserController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/controller/TimeSlotUserController.java
@@ -42,5 +42,13 @@ public class TimeSlotUserController {
                 .toList();
         return SuccessResponse.ok(response);
     }
-
+    @PatchMapping("/{timeSlotId}/users")
+    @Operation(summary = "타임슬롯 사용자 수정", description = "타임슬롯에 배정된 사용자 정보를 수정합니다.")
+    public SuccessResponse<String> updateUsersInTimeSlot(
+            @PathVariable Long timeSlotId,
+            @RequestBody @Valid TimeSlotUserRequestDTO.UpdateUsers request
+    ) {
+        timeSlotUserService.updateUsersInTimeSlot(timeSlotId, request.userIds(), request.role());
+        return SuccessResponse.ok("타임슬롯 사용자 목록이 수정되었습니다.");
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/dto/TimeSlotUserRequestDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/dto/TimeSlotUserRequestDTO.java
@@ -13,4 +13,10 @@ public class TimeSlotUserRequestDTO {
             @Schema(description = "추가할 사용자 ID 목록", example = "[1, 2]") List<Long> userIds,
             @Schema(description = "면접 역할", example = "INTERVIEWER") InterviewRole role
     ) {}
+
+    @Schema(description = "TimeSlot에 사용자 수정 요청 DTO")
+    public record UpdateUsers(
+            @Schema(description = "수정할 사용자 ID 목록", example = "[1, 2]") List<Long> userIds,
+            @Schema(description = "면접 역할", example = "INTERVIEWER") InterviewRole role
+    ) {}
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/service/TimeSlotUserService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/service/TimeSlotUserService.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface TimeSlotUserService {
     void addUsersToTimeSlot(Long timeSlotId, List<Long> userIds, InterviewRole role);
     List<TimeSlotUser> getUsersByTimeSlot(Long timeSlotId);
+    void updateUsersInTimeSlot(Long timeSlotId, List<Long> requestedUserIds, InterviewRole role);
 }

--- a/src/main/java/KUSITMS/WITHUS/global/exception/ErrorCode.java
+++ b/src/main/java/KUSITMS/WITHUS/global/exception/ErrorCode.java
@@ -95,6 +95,7 @@ public enum ErrorCode {
     // Interview (면접)
     INTERVIEW_ALREADY_EXIST("INTERVIEW400", "이미 존재하는 면접입니다.", HttpStatus.BAD_REQUEST),
     INTERVIEW_NOT_EXIST("INTERVIEW404", "존재하지 않는 면접입니다.", HttpStatus.NOT_FOUND),
+    MISMATCHED_ROOM_COUNT("INTERVIEW400", "roomNames 수가 roomCount와 일치하지 않습니다.",HttpStatus.BAD_REQUEST),
 
     // TimeSlot (면접)
     TIME_SLOT_ALREADY_EXIST("TIME_SLOT400", "이미 존재하는 TimeSlot입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/KUSITMS/WITHUS/global/exception/ErrorCode.java
+++ b/src/main/java/KUSITMS/WITHUS/global/exception/ErrorCode.java
@@ -96,6 +96,7 @@ public enum ErrorCode {
     INTERVIEW_ALREADY_EXIST("INTERVIEW400", "이미 존재하는 면접입니다.", HttpStatus.BAD_REQUEST),
     INTERVIEW_NOT_EXIST("INTERVIEW404", "존재하지 않는 면접입니다.", HttpStatus.NOT_FOUND),
     MISMATCHED_ROOM_COUNT("INTERVIEW400", "roomNames 수가 roomCount와 일치하지 않습니다.",HttpStatus.BAD_REQUEST),
+    INTERVIEW_QUESTION_NOT_EXIST("INTERVIEW_QUESTION400", "존재하지 않는 면접 질문입니다.", HttpStatus.NOT_FOUND),
 
     // TimeSlot (면접)
     TIME_SLOT_ALREADY_EXIST("TIME_SLOT400", "이미 존재하는 TimeSlot입니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
### ✨ Related Issue
- #81 
---

### 📌 Task Details
- [x] 면접 구성(면접실 명, 안내자 수 등) 면접에 필드 추가, 응답 값 설정 추가
- [x] 면접질문 수정 API 추가
- [x] 타임슬롯에 배정된 사용자 수정 API 추가

---

### 💬 Review Requirements (Optional)

