### PR TITLE
✨ 지원서 상세 조회 평가 description / 관리자용 지원서 리스트 조회 시 count 추가 구현

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/controller/AdminApplicationController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/controller/AdminApplicationController.java
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -46,8 +45,9 @@ public class AdminApplicationController {
             @RequestParam(defaultValue = "ASC") Sort.Direction direction,
             @PageableDefault(size = 7) Pageable pageable
     ) {
-        Page<ApplicationResponseDTO.SummaryForAdmin> page = applicationService.getByRecruitmentIdForAdmin(recruitmentId, stage, pageable, sortBy, direction);
-        return SuccessResponse.ok(PagedResponse.from(page));
+        ApplicationResponseDTO.AdminPageWithStageCounts result = applicationService.getByRecruitmentIdForAdmin(recruitmentId, stage, pageable, sortBy, direction);
+        PagedResponse<ApplicationResponseDTO.SummaryForAdmin> paged = PagedResponse.from(result.page(), result.counts());
+        return SuccessResponse.ok(paged);
     }
 
     @PatchMapping("/status")

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
@@ -65,9 +65,12 @@ public class ApplicationResponseDTO {
             @Schema(description = "주소") String address,
             @Schema(description = "합불 상태") ApplicationStatus status,
             @Schema(description = "지원서 항목 질문 및 답변 목록") List<ApplicationAnswerResponseDTO> documentAnswers,
+
             @Schema(description = "면접 가능 시간") @TimeFormat List<LocalDateTime> availableTimes,
             @Schema(description = "면접 질문 목록") List<InterviewQuestionResponseDTO.Detail> interviewQuestions,
-            @Schema(description = "면접 평가 목록") List<EvaluationResponseDTO.Detail> evaluations,
+
+            @Schema(description = "서류/면접 평가 목록") List<EvaluationResponseDTO.Detail> evaluations,
+
             @Schema(description = "서류 코맨트 목록") List<CommentResponseDTO.Detail> documentComments,
             @Schema(description = "면접 코맨트 목록") List<CommentResponseDTO.Detail> interviewComments,
 

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
@@ -2,6 +2,7 @@ package KUSITMS.WITHUS.domain.application.application.dto;
 
 import KUSITMS.WITHUS.domain.application.application.entity.Application;
 import KUSITMS.WITHUS.domain.application.application.enumerate.AcademicStatus;
+import KUSITMS.WITHUS.domain.application.application.enumerate.AdminStageFilter;
 import KUSITMS.WITHUS.domain.application.applicationAcquaintance.entity.ApplicationAcquaintance;
 import KUSITMS.WITHUS.domain.application.applicationAnswer.dto.ApplicationAnswerResponseDTO;
 import KUSITMS.WITHUS.domain.application.applicationEvaluator.entity.ApplicationEvaluator;
@@ -26,6 +27,7 @@ import KUSITMS.WITHUS.global.common.annotation.TimeFormat;
 import KUSITMS.WITHUS.global.common.enumerate.Gender;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
 import org.springframework.lang.Nullable;
 
 import java.math.BigDecimal;
@@ -323,6 +325,36 @@ public class ApplicationResponseDTO {
                     myScoreTotal,
                     documentMaxScore,
                     interviewSchedule
+            );
+        }
+    }
+
+    @Schema(description = "단계별 count 포함 관리자용 지원서 리스트 요약 응답 DTO")
+    public record AdminPageWithStageCounts(
+            Page<SummaryForAdmin> page,
+            StageCount counts
+    ) {
+        public static AdminPageWithStageCounts from(Page<SummaryForAdmin> page, StageCount counts) {
+            return new AdminPageWithStageCounts(
+                    page,
+                    counts
+            );
+        }
+    }
+
+    @Schema(description = "관리자용 지원서 리스트 단계별 count DTO")
+    public record StageCount(
+            long document,
+            long interview,
+            long finalPass,
+            long fail
+    ) {
+        public static StageCount from(long document, long interview, long finalPass, long fail) {
+            return new StageCount(
+                    document,
+                    interview,
+                    finalPass,
+                    fail
             );
         }
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationJpaRepository.java
@@ -13,4 +13,5 @@ public interface ApplicationJpaRepository extends JpaRepository<Application, Lon
     List<Application> findByRecruitment_IdAndPosition_Id(Long recruitmentId, Long positionId);
     Long countByRecruitment_IdAndPosition_Id(Long recruitmentId, Long positionId);
     List<Application> findDistinctByRecruitment_IdAndEvaluators_Evaluator_IdAndEvaluators_EvaluationType(Long recruitmentId, Long evaluatorId, EvaluationType evaluationType);
+    Long countByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
@@ -17,4 +17,5 @@ public interface ApplicationRepository {
     Long countByRecruitment_IdAndPosition_Id(Long recruitmentId, Long positionId);
     List<Application> findAllById(List<Long> longs);
     List<Application> findDistinctByRecruitment_IdAndEvaluators_Evaluator_IdAndEvaluators_EvaluationType(Long recruitmentId, Long evaluatorId, EvaluationType evaluationType);
+    Long countByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
@@ -77,4 +77,9 @@ public class ApplicationRepositoryImpl implements ApplicationRepository {
     public List<Application> findDistinctByRecruitment_IdAndEvaluators_Evaluator_IdAndEvaluators_EvaluationType(Long recruitmentId, Long evaluatorId, EvaluationType evaluationType) {
         return applicationJpaRepository.findDistinctByRecruitment_IdAndEvaluators_Evaluator_IdAndEvaluators_EvaluationType(recruitmentId, evaluatorId, evaluationType);
     }
+
+    @Override
+    public Long countByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses) {
+        return applicationJpaRepository.countByRecruitmentIdAndStatusIn(recruitmentId, statuses);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationService.java
@@ -19,7 +19,7 @@ public interface ApplicationService {
     void delete(Long id);
     ApplicationResponseDTO.Detail getById(Long id, Long currentUserId);
     Page<ApplicationResponseDTO.SummaryForUser> getByRecruitmentId(Long recruitmentId, Long currentUserId, EvaluationStatus evaluationStatus, String keyword, Pageable pageable);
-    Page<ApplicationResponseDTO.SummaryForAdmin> getByRecruitmentIdForAdmin(Long recruitmentId, AdminStageFilter stage, Pageable pageable, AdminApplicationSortField sortBy, Sort.Direction direction);
+    ApplicationResponseDTO.AdminPageWithStageCounts getByRecruitmentIdForAdmin(Long recruitmentId, AdminStageFilter stage, Pageable pageable, AdminApplicationSortField sortBy, Sort.Direction direction);
     List<ApplicationResponseDTO.Summary> updateStatus(ApplicationRequestDTO.UpdateStatus request);
     void distributeEvaluators(ApplicationEvaluatorRequestDTO.Distribute request);
     DistributionRequest distributeEvaluatorsLatestRequest(Long recruitmentId);

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
@@ -170,7 +170,7 @@ public class ApplicationServiceImpl implements ApplicationService {
      * @return 조회한 공고의 지원서 전체의 정보
      */
     @Override
-    public Page<ApplicationResponseDTO.SummaryForAdmin> getByRecruitmentIdForAdmin(
+    public ApplicationResponseDTO.AdminPageWithStageCounts getByRecruitmentIdForAdmin(
             Long recruitmentId,
             AdminStageFilter stage,
             Pageable pageable,
@@ -240,7 +240,22 @@ public class ApplicationServiceImpl implements ApplicationService {
                 ? List.of()
                 : allDtos.subList(start, end);
 
-        return new PageImpl<>(content, pageable, allDtos.size());
+        Page<ApplicationResponseDTO.SummaryForAdmin> page = new PageImpl<>(content, pageable, allDtos.size());
+
+        long documentCnt = applicationRepository.countByRecruitmentIdAndStatusIn(
+                recruitmentId, AdminStageFilter.DOCUMENT.toStatusList());
+        long interviewCnt = applicationRepository.countByRecruitmentIdAndStatusIn(
+                recruitmentId, AdminStageFilter.INTERVIEW.toStatusList());
+        long finalPassCnt = applicationRepository.countByRecruitmentIdAndStatusIn(
+                recruitmentId, AdminStageFilter.FINAL_PASS.toStatusList());
+        long failCnt = applicationRepository.countByRecruitmentIdAndStatusIn(
+                recruitmentId, AdminStageFilter.FAIL.toStatusList());
+
+        ApplicationResponseDTO.StageCount counts = ApplicationResponseDTO.StageCount.from(
+                documentCnt, interviewCnt, finalPassCnt, failCnt
+        );
+
+        return ApplicationResponseDTO.AdminPageWithStageCounts.from(page, counts);
     }
 
 

--- a/src/main/java/KUSITMS/WITHUS/domain/evaluation/evaluation/dto/EvaluationResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/evaluation/evaluation/dto/EvaluationResponseDTO.java
@@ -11,14 +11,14 @@ public class EvaluationResponseDTO {
     @Schema(description = "평가 정보 응답 DTO")
     public record Detail(
             @Schema(description = "평가 ID") Long id,
-            @Schema(description = "평가 기준") EvaluationCriteriaResponseDTO.Summary criteria,
+            @Schema(description = "평가 기준") EvaluationCriteriaResponseDTO.Detail criteria,
             @Schema(description = "평가 점수") int score,
             @Schema(description = "평가자") UserResponseDTO.Summary user
     ) {
         public static Detail from(Evaluation evaluation) {
             return new Detail(
                     evaluation.getId(),
-                    EvaluationCriteriaResponseDTO.Summary.from(evaluation.getCriteria()),
+                    EvaluationCriteriaResponseDTO.Detail.from(evaluation.getCriteria()),
                     evaluation.getScore(),
                     UserResponseDTO.Summary.from(evaluation.getUser())
             );

--- a/src/main/java/KUSITMS/WITHUS/global/response/PagedResponse.java
+++ b/src/main/java/KUSITMS/WITHUS/global/response/PagedResponse.java
@@ -1,12 +1,14 @@
 package KUSITMS.WITHUS.global.response;
 
+import KUSITMS.WITHUS.domain.application.application.dto.ApplicationResponseDTO;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public record PagedResponse<T>(
         List<T> data,
-        PaginationMeta pagination
+        PaginationMeta pagination,
+        ApplicationResponseDTO.StageCount counts
 ) {
     public static <T> PagedResponse<T> from(Page<T> page) {
         return new PagedResponse<>(
@@ -17,7 +19,25 @@ public record PagedResponse<T>(
                         page.getTotalPages(),
                         page.getTotalElements(),
                         page.isLast()
-                )
+                ),
+                null
+        );
+    }
+
+    public static <T> PagedResponse<T> from(
+            Page<T> page,
+            ApplicationResponseDTO.StageCount counts
+    ) {
+        return new PagedResponse<>(
+                page.getContent(),
+                new PaginationMeta(
+                        page.getNumber() + 1,
+                        page.getSize(),
+                        page.getTotalPages(),
+                        page.getTotalElements(),
+                        page.isLast()
+                ),
+                counts
         );
     }
 }


### PR DESCRIPTION
### ✨ Related Issue

- #98 

---

### 📌 Task Details
- [x] 각 서류 / 면접 / 최종 합격 / 불합격 몇 명인지 포함해서 보내게 수정
- [x] 지원서 상세 조회 시 evaluations - criteria에 description 포함되도록 수정

---

### 💬 Review Requirements (Optional)

