### PR TITLE
🐛 평가담당자 분배 수정 사항 반영 (논의사항 #4)

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/controller/AdminApplicationController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/controller/AdminApplicationController.java
@@ -71,8 +71,7 @@ public class AdminApplicationController {
     public SuccessResponse<DistributionRequestResponseDTO.Detail> latest(
             @PathVariable Long recruitmentId
     ) {
-        DistributionRequest record = applicationService.distributeEvaluatorsLatestRequest(recruitmentId);
-        return SuccessResponse.ok(DistributionRequestResponseDTO.Detail.from(record));
+        return SuccessResponse.ok(applicationService.distributeEvaluatorsLatestRequest(recruitmentId));
     }
 
     @PostMapping("/evaluators")

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/enumerate/AdminStageFilter.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/enumerate/AdminStageFilter.java
@@ -14,10 +14,10 @@ public enum AdminStageFilter {
         return switch(this) {
             case DOCUMENT -> List.of(ApplicationStatus.values());
             case INTERVIEW -> List.of(
-                    ApplicationStatus.PENDING,
                     ApplicationStatus.DOX_PASS,
                     ApplicationStatus.INTERVIEW_PASS,
-                    ApplicationStatus.INTERVIEW_FAIL
+                    ApplicationStatus.INTERVIEW_FAIL,
+                    ApplicationStatus.INTERVIEW_PENDING
             );
             case FINAL_PASS -> List.of(
                     ApplicationStatus.INTERVIEW_PASS

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationService.java
@@ -6,7 +6,7 @@ import KUSITMS.WITHUS.domain.application.application.enumerate.AdminApplicationS
 import KUSITMS.WITHUS.domain.application.application.enumerate.AdminStageFilter;
 import KUSITMS.WITHUS.domain.application.application.enumerate.EvaluationStatus;
 import KUSITMS.WITHUS.domain.application.applicationEvaluator.dto.ApplicationEvaluatorRequestDTO;
-import KUSITMS.WITHUS.domain.application.distributionRequest.entity.DistributionRequest;
+import KUSITMS.WITHUS.domain.application.distributionRequest.dto.DistributionRequestResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -22,7 +22,7 @@ public interface ApplicationService {
     ApplicationResponseDTO.AdminPageWithStageCounts getByRecruitmentIdForAdmin(Long recruitmentId, AdminStageFilter stage, Pageable pageable, AdminApplicationSortField sortBy, Sort.Direction direction);
     List<ApplicationResponseDTO.Summary> updateStatus(ApplicationRequestDTO.UpdateStatus request);
     void distributeEvaluators(ApplicationEvaluatorRequestDTO.Distribute request);
-    DistributionRequest distributeEvaluatorsLatestRequest(Long recruitmentId);
+    DistributionRequestResponseDTO.Detail distributeEvaluatorsLatestRequest(Long recruitmentId);
     void updateEvaluators(ApplicationEvaluatorRequestDTO.Update request);
     boolean toggleAcquaintance(Long applicationId, Long userId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
@@ -19,6 +19,7 @@ import KUSITMS.WITHUS.domain.application.applicationAcquaintance.repository.Appl
 import KUSITMS.WITHUS.domain.application.applicationAnswer.entity.ApplicationAnswer;
 import KUSITMS.WITHUS.domain.application.applicationAnswer.repository.ApplicationAnswerRepository;
 import KUSITMS.WITHUS.domain.application.applicationEvaluator.dto.ApplicationEvaluatorRequestDTO;
+import KUSITMS.WITHUS.domain.application.distributionRequest.dto.DistributionRequestResponseDTO;
 import KUSITMS.WITHUS.domain.application.distributionRequest.entity.DistributionRequest;
 import KUSITMS.WITHUS.domain.application.distributionRequest.repository.DistributionRequestRepository;
 import KUSITMS.WITHUS.domain.application.enumerate.ApplicationStatus;
@@ -292,8 +293,14 @@ public class ApplicationServiceImpl implements ApplicationService {
      * @param recruitmentId 공고 ID
      */
     @Override
-    public DistributionRequest distributeEvaluatorsLatestRequest(Long recruitmentId) {
-        return distributionRequestRepository.findTopByRecruitmentIdOrderByCreatedAtDesc(recruitmentId);
+    public DistributionRequestResponseDTO.Detail distributeEvaluatorsLatestRequest(Long recruitmentId) {
+        DistributionRequest latest = distributionRequestRepository.findTopByRecruitmentIdOrderByCreatedAtDesc(recruitmentId);
+
+        if (latest == null) {
+            return DistributionRequestResponseDTO.Detail.empty(recruitmentId);
+        }
+
+        return DistributionRequestResponseDTO.Detail.from(latest);
     }
 
     /**

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
@@ -268,7 +268,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     public List<ApplicationResponseDTO.Summary> updateStatus(ApplicationRequestDTO.UpdateStatus request) {
         List<Application> apps = applicationRepository.findAllById(request.applicationIds());
         apps.forEach(app -> {
-            ApplicationStatus newStatus = mapToRealStatus(request.stage(), app.getStatus(), request.status());
+            ApplicationStatus newStatus = mapToRealStatus(request.stage(), request.status());
             app.updateStatus(newStatus);
         });
         return apps.stream()
@@ -337,30 +337,23 @@ public class ApplicationServiceImpl implements ApplicationService {
      */
     private ApplicationStatus mapToRealStatus(
             AdminStageFilter stage,
-            ApplicationStatus current,
             SimpleApplicationStatus simple) {
-
-        if (simple == SimpleApplicationStatus.HOLD) {
-            return ApplicationStatus.PENDING;
-        }
 
         boolean isPass = (simple == SimpleApplicationStatus.PASS);
 
         switch (stage) {
             case DOCUMENT:
-                // 기존 면접 단계였으면 INTERVIEW_
-                if (current == ApplicationStatus.INTERVIEW_PASS
-                        || current == ApplicationStatus.INTERVIEW_FAIL) {
-                    return isPass
-                            ? ApplicationStatus.INTERVIEW_PASS
-                            : ApplicationStatus.INTERVIEW_FAIL;
+                if (simple == SimpleApplicationStatus.HOLD) {
+                    return ApplicationStatus.DOX_PENDING;
                 }
-                // 그 외(PENDING, DOX_PASS, DOX_FAIL)면 DOX_
                 return isPass
                         ? ApplicationStatus.DOX_PASS
                         : ApplicationStatus.DOX_FAIL;
 
             case INTERVIEW:
+                if (simple == SimpleApplicationStatus.HOLD) {
+                    return ApplicationStatus.INTERVIEW_PENDING;
+                }
                 return isPass
                         ? ApplicationStatus.INTERVIEW_PASS
                         : ApplicationStatus.INTERVIEW_FAIL;

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/evaluator/EvaluatorAssignmentService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/evaluator/EvaluatorAssignmentService.java
@@ -112,7 +112,10 @@ public class EvaluatorAssignmentService {
             throw new CustomException(ErrorCode.EVALUATOR_NOT_EXIST);
         }
 
-        applicationEvaluatorRepository.deleteAllByApplication_Id(application.getId());
+        applicationEvaluatorRepository.deleteAllByApplication_IdAndEvaluationType(
+                application.getId(),
+                request.evaluationType()
+        );
 
         List<ApplicationEvaluator> assigns = users.stream()
                 .map(u -> new ApplicationEvaluator(application, u, request.evaluationType()))

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/evaluator/EvaluatorAssignmentService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/evaluator/EvaluatorAssignmentService.java
@@ -67,7 +67,7 @@ public class EvaluatorAssignmentService {
 
         // 기존 배정 초기화
         Long recruitmentId = request.recruitmentId();
-        applicationEvaluatorRepository.deleteAllByApplication_Recruitment_Id(recruitmentId);
+        applicationEvaluatorRepository.deleteAllByApplication_Recruitment_IdAndEvaluationType(recruitmentId, request.evaluationType());
 
         // 파트별 배정
         Random rnd = new Random();

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/dto/ApplicationEvaluatorRequestDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/dto/ApplicationEvaluatorRequestDTO.java
@@ -17,6 +17,10 @@ public class ApplicationEvaluatorRequestDTO {
             @NotNull
             Long recruitmentId,
 
+            @Schema(description = "평가 타입", example = "DOCUMENT | INTERVIEW")
+            @NotNull
+            EvaluationType evaluationType,
+
             @Schema(description = "파트별 평가 담당자 배정 정보 리스트")
             @NotEmpty
             List<PartAssignment> assignments

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorJpaRepository.java
@@ -1,9 +1,11 @@
 package KUSITMS.WITHUS.domain.application.applicationEvaluator.repository;
 
 import KUSITMS.WITHUS.domain.application.applicationEvaluator.entity.ApplicationEvaluator;
+import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApplicationEvaluatorJpaRepository extends JpaRepository<ApplicationEvaluator, Long> {
     void deleteAllByApplication_Recruitment_Id(Long recruitmentId);
     void deleteAllByApplication_Id(Long applicationId);
+    void deleteAllByApplication_IdAndEvaluationType(Long applicationId, EvaluationType evaluationType);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorJpaRepository.java
@@ -5,7 +5,7 @@ import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationT
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApplicationEvaluatorJpaRepository extends JpaRepository<ApplicationEvaluator, Long> {
-    void deleteAllByApplication_Recruitment_Id(Long recruitmentId);
+    void deleteAllByApplication_Recruitment_IdAndEvaluationType(Long recruitmentId, EvaluationType evaluationType);
     void deleteAllByApplication_Id(Long applicationId);
     void deleteAllByApplication_IdAndEvaluationType(Long applicationId, EvaluationType evaluationType);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorRepository.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public interface ApplicationEvaluatorRepository {
-    void deleteAllByApplication_Recruitment_Id(Long recruitmentId);
+    void deleteAllByApplication_Recruitment_IdAndEvaluationType(Long recruitmentId, EvaluationType evaluationType);
     void deleteAllByApplication_Id(Long applicationId);
     List<ApplicationEvaluator> findByRecruitmentAndPositionAndType(Long recruitmentId, Long positionId, EvaluationType type);
     List<ApplicationEvaluator> findByEvaluatorAndRecruitmentAndType(Long evaluatorId, EvaluationType type, Long recruitmentId);

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorRepository.java
@@ -2,6 +2,7 @@ package KUSITMS.WITHUS.domain.application.applicationEvaluator.repository;
 
 import KUSITMS.WITHUS.domain.application.applicationEvaluator.entity.ApplicationEvaluator;
 import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationType;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
@@ -11,4 +12,5 @@ public interface ApplicationEvaluatorRepository {
     List<ApplicationEvaluator> findByRecruitmentAndPositionAndType(Long recruitmentId, Long positionId, EvaluationType type);
     List<ApplicationEvaluator> findByEvaluatorAndRecruitmentAndType(Long evaluatorId, EvaluationType type, Long recruitmentId);
     void saveAll(List<ApplicationEvaluator> assigns);
+    void deleteAllByApplication_IdAndEvaluationType(Long id, EvaluationType evaluationType);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorRepositoryImpl.java
@@ -55,4 +55,9 @@ public class ApplicationEvaluatorRepositoryImpl implements ApplicationEvaluatorR
     public void saveAll(List<ApplicationEvaluator> assigns) {
         applicationEvaluatorJpaRepository.saveAll(assigns);
     }
+
+    @Override
+    public void deleteAllByApplication_IdAndEvaluationType(Long id, EvaluationType evaluationType) {
+        applicationEvaluatorJpaRepository.deleteAllByApplication_IdAndEvaluationType(id, evaluationType);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/repository/ApplicationEvaluatorRepositoryImpl.java
@@ -18,8 +18,8 @@ public class ApplicationEvaluatorRepositoryImpl implements ApplicationEvaluatorR
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public void deleteAllByApplication_Recruitment_Id(Long recruitmentId) {
-        applicationEvaluatorJpaRepository.deleteAllByApplication_Recruitment_Id(recruitmentId);
+    public void deleteAllByApplication_Recruitment_IdAndEvaluationType(Long recruitmentId, EvaluationType evaluationType) {
+        applicationEvaluatorJpaRepository.deleteAllByApplication_Recruitment_IdAndEvaluationType(recruitmentId, evaluationType);
     }
 
     @Override

--- a/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/dto/DistributionRequestResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/dto/DistributionRequestResponseDTO.java
@@ -16,6 +16,10 @@ public class DistributionRequestResponseDTO {
             @Schema(description = "공고 id") Long recruitmentId,
             @Schema(description = "최신 요청 이력 리스트") List<Assignment> assignments
     ) {
+        public static Detail empty(Long recruitmentId) {
+            return new Detail(null, recruitmentId, List.of());
+        }
+
         public static Detail from(DistributionRequest distributionRequest) {
             List<Assignment> assignments = distributionRequest.getAssignments().stream()
                     .map(Assignment::from)

--- a/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/repository/DistributionRequestRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/repository/DistributionRequestRepositoryImpl.java
@@ -19,7 +19,7 @@ public class DistributionRequestRepositoryImpl implements DistributionRequestRep
         List<DistributionRequest> distributionRequests = findAllByRecruitmentIdOrderByCreatedAtDesc(recruitmentId);
 
         if (distributionRequests.isEmpty()) {
-            throw new CustomException(ErrorCode.DISTRIBUTION_HISTORY_NOT_FOUND);
+            return null;
         }
 
         return distributionRequests.get(0);

--- a/src/main/java/KUSITMS/WITHUS/domain/application/enumerate/ApplicationStatus.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/enumerate/ApplicationStatus.java
@@ -7,11 +7,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ApplicationStatus {
 
-    PENDING("보류"),
+    PENDING("보류"), // 지원서 생성 시 default status
     DOX_PASS("서류 합격"),
     DOX_FAIL("서류 불합격"),
+    DOX_PENDING("서류 보류"),
     INTERVIEW_PASS("면접 합격"),
-    INTERVIEW_FAIL("면접 불합격");
+    INTERVIEW_FAIL("면접 불합격"),
+    INTERVIEW_PENDING("면접 보류");
 
     private final String key;
 }


### PR DESCRIPTION
### ✨ Related Issue

- #122 

---

### 📌 Task Details
- [x] 평가담당자 분배 시 같은 지원서에 서류 평가자 분배 후 면접 평가자 분배 시 서류 평가자 분배 내역 삭제되는 문제 해결
- [x] -> 같은 지원서 + 평가 타입일때 평가담당자 테이블 리셋하도록 수정
- [x] 관리자 지원서 리스트 조회 시 면접 탭에서 그냥 '보류'인 지원자 보이지 않도록 수정
- [x] 지원서 상태 - 서류 보류, 면접 보류 추가 + 기존의 PENDING(보류)는 지원서 생성 시 디폴트 값으로 설정
- [x] 담당자 분배 최신 결과 조회 시 분배 이력 없으면 빈 리스트 반환하도록 수정

---

### 💬 Review Requirements (Optional)

