### PR TITLE
🐛 관리자용 지원서 관련 수정 

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
@@ -22,6 +22,7 @@ import KUSITMS.WITHUS.domain.recruitment.recruitment.entity.Recruitment;
 import KUSITMS.WITHUS.domain.user.user.dto.UserResponseDTO;
 import KUSITMS.WITHUS.global.common.annotation.DateFormatDot;
 import KUSITMS.WITHUS.global.common.annotation.DateFormatSlash;
+import KUSITMS.WITHUS.global.common.annotation.DateTimeFormat;
 import KUSITMS.WITHUS.global.common.annotation.TimeFormat;
 import KUSITMS.WITHUS.global.common.enumerate.Gender;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -65,7 +66,7 @@ public class ApplicationResponseDTO {
             @Schema(description = "합불 상태") ApplicationStatus status,
             @Schema(description = "지원서 항목 질문 및 답변 목록") List<ApplicationAnswerResponseDTO> documentAnswers,
 
-            @Schema(description = "면접 가능 시간") @TimeFormat List<LocalDateTime> availableTimes,
+            @Schema(description = "면접 가능 시간") @DateTimeFormat List<LocalDateTime> availableTimes,
             @Schema(description = "면접 질문 목록") List<InterviewQuestionResponseDTO.Detail> interviewQuestions,
 
             @Schema(description = "서류/면접 평가 목록") List<EvaluationResponseDTO.Detail> evaluations,

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
@@ -104,7 +104,9 @@ public class ApplicationServiceImpl implements ApplicationService {
 
         FileResponseDTO.Upload uploadData = fileUploadService.uploadProfileImage(profileImage,
                 recruitment.getOrganization().getId(), recruitment.getId(), application.getId());
-        application.updateImageUrl(uploadData.url());
+        if (uploadData != null) {
+            application.updateImageUrl(uploadData.url());
+        }
 
         saveApplicantAvailabilities(application, request.availableTimes());
 

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
@@ -41,6 +41,7 @@ import KUSITMS.WITHUS.global.exception.ErrorCode;
 import KUSITMS.WITHUS.global.infra.email.sender.MailSender;
 import KUSITMS.WITHUS.global.infra.email.template.MailTemplateProvider;
 import KUSITMS.WITHUS.global.infra.email.template.MailTemplateType;
+import KUSITMS.WITHUS.global.infra.upload.dto.FileResponseDTO;
 import KUSITMS.WITHUS.global.infra.upload.service.FileUploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -101,9 +102,9 @@ public class ApplicationServiceImpl implements ApplicationService {
         Application application = factory.createApplication(request, recruitment, position);
         applicationRepository.save(application);
 
-        String imageUrl = fileUploadService.uploadProfileImage(profileImage,
+        FileResponseDTO.Upload uploadData = fileUploadService.uploadProfileImage(profileImage,
                 recruitment.getOrganization().getId(), recruitment.getId(), application.getId());
-        application.updateImageUrl(imageUrl);
+        application.updateImageUrl(uploadData.url());
 
         saveApplicantAvailabilities(application, request.availableTimes());
 
@@ -111,7 +112,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         List<DocumentQuestion> questions = documentQuestionRepository.findCommonAndByPosition(recruitment, position);
         validator.validateFileAnswers(request.answers(), fileList, questions);
 
-        Map<String, String> uploadedFileUrls = fileUploadService.uploadAnswerFiles(fileList,
+        Map<String, FileResponseDTO.Upload> uploadedFileUrls = fileUploadService.uploadAnswerFiles(fileList,
                 recruitment.getOrganization().getId(), recruitment.getId(), application.getId());
 
         Map<Long, DocumentQuestion> questionMap = questions.stream()
@@ -349,7 +350,6 @@ public class ApplicationServiceImpl implements ApplicationService {
     /**
      * PASS/FAIL/HOLD의 간단 상태를 단계와 현재 상태에 맞춰 ApplicationStatus으로 매핑
      * @param stage   변경할 단계 (DOCUMENT, INTERVIEW, FINAL_PASS, FAIL)
-     * @param current 현재 ApplicationStatus (PENDING, DOX_PASS, 등)
      * @param simple  간단 상태 (PASS, FAIL, HOLD)
      */
     private ApplicationStatus mapToRealStatus(

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/factory/ApplicationFactory.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/factory/ApplicationFactory.java
@@ -8,6 +8,7 @@ import KUSITMS.WITHUS.domain.recruitment.documentQuestion.entity.DocumentQuestio
 import KUSITMS.WITHUS.domain.recruitment.documentQuestion.enumerate.QuestionType;
 import KUSITMS.WITHUS.domain.recruitment.position.entity.Position;
 import KUSITMS.WITHUS.domain.recruitment.recruitment.entity.Recruitment;
+import KUSITMS.WITHUS.global.infra.upload.dto.FileResponseDTO;
 import org.springframework.stereotype.Component;
 
 import java.text.Normalizer;
@@ -37,16 +38,23 @@ public class ApplicationFactory {
     public List<ApplicationAnswer> createAnswers(Application application,
                                                  List<ApplicationAnswerRequestDTO> answerDTOs,
                                                  Map<Long, DocumentQuestion> questionMap,
-                                                 Map<String, String> uploadedFileUrls) {
+                                                 Map<String, FileResponseDTO.Upload> uploadedFiles) {
         return answerDTOs.stream()
                 .map(dto -> {
                     DocumentQuestion question = questionMap.get(dto.questionId());
                     String fileUrl = null;
+                    Long fileSize = null;
+
                     if (question.getType() == QuestionType.FILE && dto.fileName() != null) {
-                        String normalizedDtoFileName = Normalizer.normalize(dto.fileName(), Normalizer.Form.NFC);
-                        fileUrl = uploadedFileUrls.get(normalizedDtoFileName);
+                        String normalizedFileName = Normalizer.normalize(dto.fileName(), Normalizer.Form.NFC);
+                        FileResponseDTO.Upload fileData = uploadedFiles.get(normalizedFileName);
+
+                        if (fileData != null) {
+                            fileUrl = fileData.url();
+                            fileSize = fileData.size();
+                        }
                     }
-                    return ApplicationAnswer.create(application, question, dto.answerText(), fileUrl);
+                    return ApplicationAnswer.create(application, question, dto.answerText(), fileUrl, fileSize);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationAnswer/dto/ApplicationAnswerResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationAnswer/dto/ApplicationAnswerResponseDTO.java
@@ -3,6 +3,7 @@ package KUSITMS.WITHUS.domain.application.applicationAnswer.dto;
 import KUSITMS.WITHUS.domain.application.applicationAnswer.entity.ApplicationAnswer;
 import KUSITMS.WITHUS.domain.recruitment.documentQuestion.entity.DocumentQuestion;
 import KUSITMS.WITHUS.domain.recruitment.documentQuestion.enumerate.QuestionType;
+import KUSITMS.WITHUS.global.infra.upload.util.FileSizeConverter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ApplicationAnswerResponseDTO(
@@ -11,7 +12,8 @@ public record ApplicationAnswerResponseDTO(
         @Schema(description = "질문 제목") String questionDescription,
         @Schema(description = "질문 방식 - TEXT, FILE") QuestionType questionType,
         @Schema(description = "답변 내용") String answerText,
-        @Schema(description = "탑변 파일") String fileUrl,
+        @Schema(description = "답변 파일") String fileUrl,
+        @Schema(description = "답변 파일 크기 (MB)") Double fileSize,
 
         // TEXT
         @Schema(description = "최대 글자 수") Integer textLimit,
@@ -23,6 +25,9 @@ public record ApplicationAnswerResponseDTO(
 ) {
     public static ApplicationAnswerResponseDTO from(ApplicationAnswer answer) {
         DocumentQuestion question = answer.getQuestion();
+        Double fileSizeMb = answer.getFileSize() != null
+                ? FileSizeConverter.toMegabytes(answer.getFileSize())
+                : null;
 
         return new ApplicationAnswerResponseDTO(
                 question.getId(),
@@ -31,6 +36,7 @@ public record ApplicationAnswerResponseDTO(
                 question.getType(),
                 answer.getAnswerText(),
                 answer.getFileUrl(),
+                fileSizeMb,
 
                 // TEXT
                 question.getType() == QuestionType.TEXT ? question.getTextLimit() : null,

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationAnswer/entity/ApplicationAnswer.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationAnswer/entity/ApplicationAnswer.java
@@ -30,12 +30,16 @@ public class ApplicationAnswer {
     @Column(name = "FILE_URL")
     private String fileUrl;
 
-    public static ApplicationAnswer create(Application app, DocumentQuestion question, String answerText, String fileUrl) {
+    @Column(name = "FILE_SIZE")
+    private Long fileSize;
+
+    public static ApplicationAnswer create(Application app, DocumentQuestion question, String answerText, String fileUrl, Long fileSize) {
         return ApplicationAnswer.builder()
                 .application(app)
                 .question(question)
                 .answerText(answerText)
                 .fileUrl(fileUrl)
+                .fileSize(fileSize)
                 .build();
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserServiceImpl.java
@@ -12,6 +12,7 @@ import KUSITMS.WITHUS.domain.user.userOrganization.entity.UserOrganization;
 import KUSITMS.WITHUS.global.common.enumerate.Gender;
 import KUSITMS.WITHUS.global.exception.CustomException;
 import KUSITMS.WITHUS.global.exception.ErrorCode;
+import KUSITMS.WITHUS.global.infra.upload.dto.FileResponseDTO;
 import KUSITMS.WITHUS.global.infra.upload.service.FileUploadService;
 import KUSITMS.WITHUS.global.util.redis.VerificationCache;
 import lombok.Builder;
@@ -247,7 +248,8 @@ public class UserServiceImpl implements UserService {
             if (imageUrl != null) {
                 uploadService.delete(imageUrl);
             }
-            imageUrl = uploadService.uploadUserProfileImage(profileImage, user.getId());
+            FileResponseDTO.Upload uploaded = uploadService.uploadUserProfileImage(profileImage, user.getId());
+            imageUrl = uploaded != null ? uploaded.url() : null;
         }
 
         user.update(request.name(), request.phoneNumber(), encodedPassword, imageUrl);

--- a/src/main/java/KUSITMS/WITHUS/global/infra/upload/controller/FileController.java
+++ b/src/main/java/KUSITMS/WITHUS/global/infra/upload/controller/FileController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,8 +29,11 @@ public class FileController {
         try {
             InputStream in = new URL(request.imageUrl()).openStream();
 
+            String encodedFileName = URLEncoder.encode(request.fileName(), StandardCharsets.UTF_8)
+                    .replaceAll("\\+", "%20");
+
             HttpHeaders headers = new HttpHeaders();
-            headers.add("Content-Disposition", "attachment; filename=" + request.fileName());
+            headers.add("Content-Disposition", "attachment; filename=" + encodedFileName);
 
             return ResponseEntity.ok()
                     .headers(headers)

--- a/src/main/java/KUSITMS/WITHUS/global/infra/upload/dto/FileResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/global/infra/upload/dto/FileResponseDTO.java
@@ -1,0 +1,16 @@
+package KUSITMS.WITHUS.global.infra.upload.dto;
+
+public class FileResponseDTO {
+
+    public record Upload(
+            String fileName,
+            String url,
+            long size
+    ) {
+        public static FileResponseDTO.Upload from(String fileName, String url, long size) {
+            return new FileResponseDTO.Upload(
+                    fileName, url, size
+            );
+        }
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/global/infra/upload/service/FileUploadService.java
+++ b/src/main/java/KUSITMS/WITHUS/global/infra/upload/service/FileUploadService.java
@@ -2,6 +2,7 @@ package KUSITMS.WITHUS.global.infra.upload.service;
 
 import KUSITMS.WITHUS.global.exception.CustomException;
 import KUSITMS.WITHUS.global.exception.ErrorCode;
+import KUSITMS.WITHUS.global.infra.upload.dto.FileResponseDTO;
 import KUSITMS.WITHUS.global.infra.upload.uploader.Uploader;
 import KUSITMS.WITHUS.global.infra.upload.util.FilePathBuilder;
 import lombok.RequiredArgsConstructor;
@@ -26,29 +27,29 @@ public class FileUploadService {
     @Value("${ncp.storage.bucket-name}")
     private String bucketName;
 
-    public String uploadUserProfileImage(MultipartFile file, Long userId) {
+    public FileResponseDTO.Upload uploadUserProfileImage(MultipartFile file, Long userId) {
         if (file == null || file.isEmpty()) return null;
 
         String path = pathBuilder.buildUploadPath("users", String.valueOf(userId), "profile", file.getOriginalFilename());
         return uploader.upload(file, path);
     }
 
-    public String uploadProfileImage(MultipartFile file, Long orgId, Long recruitmentId, Long appId) {
+    public FileResponseDTO.Upload uploadProfileImage(MultipartFile file, Long orgId, Long recruitmentId, Long appId) {
         if (file == null || file.isEmpty()) return null;
 
         String path = pathBuilder.buildUploadPath("applications", String.valueOf(orgId), String.valueOf(recruitmentId), String.valueOf(appId), "profile", file.getOriginalFilename());
         return uploader.upload(file, path);
     }
 
-    public Map<String, String> uploadAnswerFiles(List<MultipartFile> files, Long orgId, Long recruitmentId, Long appId) {
-        Map<String, String> result = new HashMap<>();
+    public Map<String, FileResponseDTO.Upload> uploadAnswerFiles(List<MultipartFile> files, Long orgId, Long recruitmentId, Long appId) {
+        Map<String, FileResponseDTO.Upload> result = new HashMap<>();
         if (files == null) return result;
 
         for (MultipartFile file : files) {
             String normalizedFileName = Normalizer.normalize(Objects.requireNonNull(file.getOriginalFilename()), Normalizer.Form.NFC);
             String path = pathBuilder.buildUploadPath("applications", String.valueOf(orgId), String.valueOf(recruitmentId), String.valueOf(appId), "answer", normalizedFileName);
-            String url = uploader.upload(file, path);
-            result.put(normalizedFileName, url);
+            FileResponseDTO.Upload uploadData = uploader.upload(file, path);
+            result.put(normalizedFileName, uploadData);
         }
 
         return result;

--- a/src/main/java/KUSITMS/WITHUS/global/infra/upload/uploader/NcpObjectUploader.java
+++ b/src/main/java/KUSITMS/WITHUS/global/infra/upload/uploader/NcpObjectUploader.java
@@ -2,6 +2,7 @@ package KUSITMS.WITHUS.global.infra.upload.uploader;
 
 import KUSITMS.WITHUS.global.exception.CustomException;
 import KUSITMS.WITHUS.global.exception.ErrorCode;
+import KUSITMS.WITHUS.global.infra.upload.dto.FileResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -30,7 +31,7 @@ public class NcpObjectUploader implements Uploader {
     private String endpoint;
 
     @Override
-    public String upload(MultipartFile file, String pathPrefix) {
+    public FileResponseDTO.Upload upload(MultipartFile file, String pathPrefix) {
         try {
             String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
             String key = (pathPrefix != null ? pathPrefix : "") + fileName;
@@ -45,7 +46,8 @@ public class NcpObjectUploader implements Uploader {
             PutObjectResponse response = s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
 
             if (response.sdkHttpResponse().isSuccessful()) {
-                return String.format("%s/%s/%s", endpoint, bucketName, key);
+                String url = String.format("%s/%s/%s", endpoint, bucketName, key);
+                return FileResponseDTO.Upload.from(file.getOriginalFilename(), url, file.getSize());
             } else {
                 throw new CustomException(ErrorCode.FILE_UPLOAD_FAIL);
             }

--- a/src/main/java/KUSITMS/WITHUS/global/infra/upload/uploader/Uploader.java
+++ b/src/main/java/KUSITMS/WITHUS/global/infra/upload/uploader/Uploader.java
@@ -1,8 +1,9 @@
 package KUSITMS.WITHUS.global.infra.upload.uploader;
 
+import KUSITMS.WITHUS.global.infra.upload.dto.FileResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface Uploader {
-    String upload(MultipartFile file, String pathPrefix);
+    FileResponseDTO.Upload upload(MultipartFile file, String pathPrefix);
     void delete(String key);
 }

--- a/src/main/java/KUSITMS/WITHUS/global/infra/upload/util/FileSizeConverter.java
+++ b/src/main/java/KUSITMS/WITHUS/global/infra/upload/util/FileSizeConverter.java
@@ -1,0 +1,12 @@
+package KUSITMS.WITHUS.global.infra.upload.util;
+
+public class FileSizeConverter {
+    private static final double BYTE_TO_MB = 1024.0 * 1024.0;
+
+    /**
+     * Byte 단위를 MB로 변환 (소수점 1자리까지 반올림)
+     */
+    public static double toMegabytes(long bytes) {
+        return Math.round((bytes / BYTE_TO_MB) * 10) / 10.0;
+    }
+}

--- a/src/test/java/KUSITMS/WITHUS/util/FakeUploader.java
+++ b/src/test/java/KUSITMS/WITHUS/util/FakeUploader.java
@@ -1,5 +1,6 @@
 package KUSITMS.WITHUS.util;
 
+import KUSITMS.WITHUS.global.infra.upload.dto.FileResponseDTO;
 import KUSITMS.WITHUS.global.infra.upload.uploader.Uploader;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -8,11 +9,12 @@ import java.util.UUID;
 public class FakeUploader implements Uploader {
 
     @Override
-    public String upload(MultipartFile file, String pathPrefix) {
+    public FileResponseDTO.Upload upload(MultipartFile file, String pathPrefix) {
         String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
         String fakeUrl = String.format("https://fake-storage.com/%s/%s", pathPrefix != null ? pathPrefix : "test", fileName);
+        long size = file.getSize();
         System.out.println("📤 [FAKE 업로드] 파일: " + file.getOriginalFilename() + " → URL: " + fakeUrl);
-        return fakeUrl;
+        return FileResponseDTO.Upload.from(fileName, fakeUrl, size);
     }
 
     @Override


### PR DESCRIPTION
### ✨ Related Issue
- #129 
---

### 📌 Task Details
- [x] 면접 가능 시간 데이터 포맷 변경 (TimeFormat -> DataTimeFormat)
- [x] 지원서 응답에서 파일 크기 응답 추가
- [x] 파일 다운로드 API에 한글 인코딩 추가 (배포 후 확인 필요)

---

### 💬 Review Requirements (Optional)
관리자 지원서 관련 수정 요청 1~3번에 대해 수정했습니다. 3번 경우는 배포 후 프론트에 테스트 부탁해봐야 할 거 같아요 !
