### PR TITLE
🐛 타임테이블 재생성시 기존 데이터 삭제, 관리자의 코멘트 조회 조건 수정

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/application/comment/repository/CommentRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/comment/repository/CommentRepository.java
@@ -7,7 +7,8 @@ import java.util.List;
 
 public interface CommentRepository {
     Comment save(Comment comment);
-    List<Comment> findByApplicationIdAndTypeAndCreatedBy(Long applicationId, CommentType type, Long userId);
+    List<Comment> findByApplicationIdAndTypeAndUser(Long applicationId, CommentType type, Long userId);
+    List<Comment> findByApplicationIdAndType(Long id, CommentType commentType);
     Comment getById(Long commentId);
     void delete(Comment comment);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/comment/repository/CommentRepositoryImpl.java
@@ -25,13 +25,24 @@ public class CommentRepositoryImpl implements CommentRepository {
     }
 
     @Override
-    public List<Comment> findByApplicationIdAndTypeAndCreatedBy(Long applicationId, CommentType type, Long userId) {
+    public List<Comment> findByApplicationIdAndTypeAndUser(Long applicationId, CommentType type, Long userId) {
         return queryFactory
                 .selectFrom(comment)
                 .where(
                         comment.application.id.eq(applicationId),
                         comment.type.eq(type),
                         comment.user.id.eq(userId)
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<Comment> findByApplicationIdAndType(Long applicationId, CommentType type) {
+        return queryFactory
+                .selectFrom(comment)
+                .where(
+                        comment.application.id.eq(applicationId),
+                        comment.type.eq(type)
                 )
                 .fetch();
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewSchedulerService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewSchedulerService.java
@@ -197,7 +197,7 @@ public class InterviewSchedulerService {
         Interview interview = interviewRepository.getById(interviewId);
         Recruitment recruitment = interview.getRecruitment();
 
-        List<TimeSlot> slots = timeSlotRepository.findByInterview(interview);
+        List<TimeSlot> slots = timeSlotRepository.findByInterviewId(interview.getId());
         return buildScheduleDTOs(interview, recruitment, slots, false);
     }
 
@@ -216,7 +216,7 @@ public class InterviewSchedulerService {
                 .map(TimeSlot::getId)
                 .collect(Collectors.toSet());
 
-        List<TimeSlot> mySlots = timeSlotRepository.findByInterview(interview).stream()
+        List<TimeSlot> mySlots = timeSlotRepository.findByInterviewId(interview.getId()).stream()
                 .filter(slot -> mySlotIds.contains(slot.getId()))
                 .toList();
 

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewSchedulerService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewSchedulerService.java
@@ -54,6 +54,9 @@ public class InterviewSchedulerService {
         List<ApplicantAvailability> availabilityList = availabilityRepository.findByApplicationIn(applicants);
         Interview interview = interviewRepository.getById(interviewId);
 
+        // 재생성시 기존에 배정된 타임슬롯 삭제
+        timeSlotRepository.deleteAllByInterview(interview.getId());
+
         interview.setConfig(config.interviewerPerSlot, config.applicantPerSlot, config.assistantPerSlot, config.roomCount());
         interview.setRoomNames(config.roomNames());
 

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interviewAvailabiliy/repository/InterviewerAvailabilityJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interviewAvailabiliy/repository/InterviewerAvailabilityJpaRepository.java
@@ -3,5 +3,8 @@ package KUSITMS.WITHUS.domain.interview.interviewAvailabiliy.repository;
 import KUSITMS.WITHUS.domain.interview.interviewAvailabiliy.entity.InterviewerAvailability;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface InterviewerAvailabilityJpaRepository extends JpaRepository<InterviewerAvailability, Long> {
+    List<InterviewerAvailability> findByInterviewId(Long interviewId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interviewAvailabiliy/repository/InterviewerAvailabilityRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interviewAvailabiliy/repository/InterviewerAvailabilityRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface InterviewerAvailabilityRepository {
     List<InterviewerAvailability> saveAll(List<InterviewerAvailability> availabilities);
+    List<InterviewerAvailability> findByInterviewId(Long interviewId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interviewAvailabiliy/repository/InterviewerAvailabilityRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interviewAvailabiliy/repository/InterviewerAvailabilityRepositoryImpl.java
@@ -16,4 +16,9 @@ public class InterviewerAvailabilityRepositoryImpl implements InterviewerAvailab
     public List<InterviewerAvailability> saveAll(List<InterviewerAvailability> availabilities) {
         return availabilityJpaRepository.saveAll(availabilities);
     }
+
+    @Override
+    public List<InterviewerAvailability> findByInterviewId(Long interviewId) {
+        return availabilityJpaRepository.findByInterviewId(interviewId);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotJpaRepository.java
@@ -1,11 +1,8 @@
 package KUSITMS.WITHUS.domain.interview.timeslot.repository;
 
-import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface TimeSlotJpaRepository extends JpaRepository<TimeSlot, Long> {
-    List<TimeSlot> findByInterview(Interview interview);
+    void deleteByInterviewId(Long interviewId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepository.java
@@ -15,7 +15,7 @@ public interface TimeSlotRepository {
     TimeSlot save(TimeSlot timeSlot);
     Optional<TimeSlot> findByDateTimeAndInterviewIdAndPosition(LocalDate date, LocalTime startTime, Long interviewId, Long positionId, String roomName);
     TimeSlot findOrCreate(LocalDate date, LocalTime startTime, LocalTime endTime, Interview interview, Position position, String roomName);
-    List<TimeSlot> findByInterview(Interview interview);
+    List<TimeSlot> findByInterviewId(Long interviewId);
     List<TimeSlot> findAllByUserInvolved(Long interviewId, User user);
     void deleteAllByInterview(Long interviewId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepository.java
@@ -17,4 +17,5 @@ public interface TimeSlotRepository {
     TimeSlot findOrCreate(LocalDate date, LocalTime startTime, LocalTime endTime, Interview interview, Position position, String roomName);
     List<TimeSlot> findByInterview(Interview interview);
     List<TimeSlot> findAllByUserInvolved(Long interviewId, User user);
+    void deleteAllByInterview(Long interviewId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepositoryImpl.java
@@ -93,4 +93,9 @@ public class TimeSlotRepositoryImpl implements TimeSlotRepository {
                 .orderBy(timeSlot.date.asc(), timeSlot.startTime.asc())
                 .fetch();
     }
+
+    @Override
+    public void deleteAllByInterview(Long interviewId) {
+        timeSlotJpaRepository.deleteByInterviewId(interviewId);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepositoryImpl.java
@@ -73,10 +73,10 @@ public class TimeSlotRepositoryImpl implements TimeSlotRepository {
     }
 
     @Override
-    public List<TimeSlot> findByInterview(Interview interview) {
+    public List<TimeSlot> findByInterviewId(Long interviewId) {
         return queryFactory
                 .selectFrom(timeSlot)
-                .where(timeSlot.interview.eq(interview))
+                .where(timeSlot.interview.id.eq(interviewId))
                 .orderBy(timeSlot.date.asc(), timeSlot.startTime.asc())
                 .fetch();
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
@@ -8,6 +8,9 @@ import KUSITMS.WITHUS.domain.evaluation.evaluation.entity.Evaluation;
 import KUSITMS.WITHUS.domain.evaluation.evaluation.repository.EvaluationRepository;
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
 import KUSITMS.WITHUS.domain.interview.timeslot.repository.TimeSlotRepository;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,20 +25,27 @@ public class TimeSlotServiceImpl implements TimeSlotService {
     private final TimeSlotRepository timeSlotRepository;
     private final EvaluationRepository evaluationRepository;
     private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
 
 
     @Override
     public List<ApplicationResponseDTO.DetailForTimeSlot> getApplicationsByTimeSlotFilteredByUser(Long timeSlotId, Long currentUserId) {
         TimeSlot timeSlot = timeSlotRepository.getById(timeSlotId);
 
+        User user = userRepository.getById(currentUserId);
+        boolean isAdmin = user.getRole() == Role.ADMIN;
+
         return timeSlot.getApplications().stream()
                 .map(application -> {
                     List<Evaluation> evaluations = evaluationRepository.findEvaluationsForApplication(application.getId());
 
-                    List<Comment> documentComments = commentRepository.findByApplicationIdAndTypeAndCreatedBy(
-                            application.getId(), CommentType.DOCUMENT, currentUserId);
-                    List<Comment> interviewComments = commentRepository.findByApplicationIdAndTypeAndCreatedBy(
-                            application.getId(), CommentType.INTERVIEW, currentUserId);
+                    List<Comment> documentComments = isAdmin
+                            ? commentRepository.findByApplicationIdAndType(application.getId(), CommentType.DOCUMENT)
+                            : commentRepository.findByApplicationIdAndTypeAndUser(application.getId(), CommentType.DOCUMENT, currentUserId);
+
+                    List<Comment> interviewComments = isAdmin
+                            ? commentRepository.findByApplicationIdAndType(application.getId(), CommentType.INTERVIEW)
+                            : commentRepository.findByApplicationIdAndTypeAndUser(application.getId(), CommentType.INTERVIEW, currentUserId);
 
                     return ApplicationResponseDTO.DetailForTimeSlot.from(application, timeSlot, evaluations, documentComments, interviewComments);
                 })

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/controller/TimeSlotUserController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/controller/TimeSlotUserController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/timeslots")
-@Tag(name = "TimeSlot에 사용자 추가 API")
+@Tag(name = "TimeSlot에 사용자 추가")
 @RequiredArgsConstructor
 public class TimeSlotUserController {
 
@@ -51,4 +51,14 @@ public class TimeSlotUserController {
         timeSlotUserService.updateUsersInTimeSlot(timeSlotId, request.userIds(), request.role());
         return SuccessResponse.ok("타임슬롯 사용자 목록이 수정되었습니다.");
     }
+
+    @PostMapping("/interviews/{interviewId}/schedule")
+    @Operation(summary = "면접관 자동 배정", description = "운영진 가능 시간에 따라 타임슬롯에 면접관을 자동 배정합니다.")
+    public SuccessResponse<String> assignUsersToTimeSlots(
+            @PathVariable Long interviewId
+    ) {
+        timeSlotUserService.assignInterviewers(interviewId);
+        return SuccessResponse.ok("면접관 자동 배정이 완료되었습니다.");
+    }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserJpaRepository.java
@@ -1,12 +1,10 @@
 package KUSITMS.WITHUS.domain.interview.timeslotUser.repository;
 
-import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface TimeSlotUserRepository {
-    void save(TimeSlotUser timeSlotUser);
+public interface TimeSlotUserJpaRepository extends JpaRepository<TimeSlotUser, Long> {
     List<TimeSlotUser> findByTimeSlotId(Long timeSlotId);
-    void deleteByInterviewIdAndRole(Long interviewId, InterviewRole role);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserRepositoryImpl.java
@@ -1,0 +1,39 @@
+package KUSITMS.WITHUS.domain.interview.timeslotUser.repository;
+
+import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static KUSITMS.WITHUS.domain.interview.timeslotUser.entity.QTimeSlotUser.timeSlotUser;
+
+@Repository
+@RequiredArgsConstructor
+public class TimeSlotUserRepositoryImpl implements TimeSlotUserRepository {
+
+    private final TimeSlotUserJpaRepository timeSlotUserJpaRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void save(TimeSlotUser timeSlotUser) {
+        timeSlotUserJpaRepository.save(timeSlotUser);
+    }
+
+    @Override
+    public List<TimeSlotUser> findByTimeSlotId(Long timeSlotId) {
+        return  timeSlotUserJpaRepository.findByTimeSlotId(timeSlotId);
+    }
+
+    @Override
+    public void deleteByInterviewIdAndRole(Long interviewId, InterviewRole role) {
+        queryFactory.delete(timeSlotUser)
+                .where(
+                        timeSlotUser.timeSlot.interview.id.eq(interviewId),
+                        timeSlotUser.role.eq(role)
+                )
+                .execute();
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/service/TimeSlotUserService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/service/TimeSlotUserService.java
@@ -9,4 +9,5 @@ public interface TimeSlotUserService {
     void addUsersToTimeSlot(Long timeSlotId, List<Long> userIds, InterviewRole role);
     List<TimeSlotUser> getUsersByTimeSlot(Long timeSlotId);
     void updateUsersInTimeSlot(Long timeSlotId, List<Long> requestedUserIds, InterviewRole role);
+    void assignInterviewers(Long interviewId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/service/TimeSlotUserServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/service/TimeSlotUserServiceImpl.java
@@ -1,23 +1,28 @@
 package KUSITMS.WITHUS.domain.interview.timeslotUser.service;
 
 import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
+import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
+import KUSITMS.WITHUS.domain.interview.interview.repository.InterviewRepository;
+import KUSITMS.WITHUS.domain.interview.interviewAvailabiliy.entity.InterviewerAvailability;
+import KUSITMS.WITHUS.domain.interview.interviewAvailabiliy.repository.InterviewerAvailabilityRepository;
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
 import KUSITMS.WITHUS.domain.interview.timeslot.repository.TimeSlotRepository;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.repository.TimeSlotUserRepository;
+import KUSITMS.WITHUS.domain.recruitment.position.entity.Position;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
 import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -26,6 +31,8 @@ public class TimeSlotUserServiceImpl implements TimeSlotUserService {
     private final TimeSlotRepository timeSlotRepository;
     private final UserRepository userRepository;
     private final TimeSlotUserRepository timeSlotUserRepository;
+    private final InterviewRepository interviewRepository;
+    private final InterviewerAvailabilityRepository interviewerAvailabilityRepository;
 
     @Override
     @Transactional
@@ -87,5 +94,92 @@ public class TimeSlotUserServiceImpl implements TimeSlotUserService {
                     .build();
             timeSlot.getTimeSlotUsers().add(newRelation);
         }
+    }
+
+    @Override
+    @Transactional
+    public void assignInterviewers(Long interviewId) {
+        // 기존 면접관 배정 삭제
+        timeSlotUserRepository.deleteByInterviewIdAndRole(interviewId, InterviewRole.INTERVIEWER);
+
+        Interview interview = interviewRepository.getById(interviewId);
+        List<TimeSlot> timeSlots = timeSlotRepository.findByInterviewId(interviewId);
+        List<InterviewerAvailability> availabilities = interviewerAvailabilityRepository.findByInterviewId(interviewId);
+
+        log.info("[1] 타임슬롯 수: {}", timeSlots.size());
+        log.info("[2] 인터뷰어 가능 시간 제출 수: {}", availabilities.size());
+
+        Map<Long, List<LocalDateTime>> userAvailableTimes = availabilities.stream()
+                .collect(Collectors.groupingBy(
+                        a -> a.getUser().getId(),
+                        Collectors.mapping(InterviewerAvailability::getAvailableTime, Collectors.toList())
+                ));
+
+        log.info("[3] 가능한 유저 수: {}", userAvailableTimes.size());
+
+        Map<Long, User> userMap = userRepository.findAllById(new ArrayList<>(userAvailableTimes.keySet()))
+                .stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        Set<Long> usedUsers = new HashSet<>();
+
+        for (TimeSlot slot : timeSlots) {
+            LocalDateTime slotTime = slot.getDate().atTime(slot.getStartTime());
+            Position slotPosition = slot.getPosition();
+
+            log.info("[4] 타임슬롯 ID: {} / 시간: {} / 포지션: {}",
+                    slot.getId(), slotTime, slotPosition != null ? slotPosition.getName() : "null");
+
+            List<Long> assignableUserIds = userAvailableTimes.entrySet().stream()
+                    .filter(e -> {
+                        boolean hasTime = e.getValue().contains(slotTime);
+                        if (!hasTime) {
+                            log.debug("[FAIL] userId={} 는 시간 불일치", e.getKey());
+                        }
+                        return hasTime;
+                    })
+                    .map(Map.Entry::getKey)
+                    .filter(userId -> {
+                        User user = userMap.get(userId);
+                        boolean alreadyUsed = usedUsers.contains(userId);
+                        boolean matchRole = slotPosition == null || user.hasMatchingRole(slotPosition);
+
+                        if (alreadyUsed) {
+                            log.debug("[FAIL] userId={} ({}) 이미 배정됨", userId, user.getName());
+                            return false;
+                        }
+                        if (!matchRole) {
+                            log.debug("[FAIL] userId={} ({}) 포지션 불일치", userId, user.getName());
+                            log.debug("유저 역할 목록: {}", user.getUserOrganizationRoles().stream()
+                                    .map(r -> r.getOrganizationRole().getName())
+                                    .toList());
+                        }
+
+                        return matchRole;
+                    })
+                    .limit(interview.getInterviewerPerSlot())
+                    .toList();
+
+            for (Long userId : assignableUserIds) {
+                User user = userMap.get(userId);
+                assignToSlot(slot, user, InterviewRole.INTERVIEWER);
+                usedUsers.add(userId);
+                log.info("[SUCCESS] 배정: userId={} ({})", userId, user.getName());
+            }
+
+            if (assignableUserIds.isEmpty()) {
+                log.warn("[WARN] 배정 가능한 운영진 없음 (timeSlotId={})", slot.getId());
+            }
+        }
+    }
+    
+    private void assignToSlot(TimeSlot slot, User user, InterviewRole role) {
+        TimeSlotUser tsu = TimeSlotUser.builder()
+                .timeSlot(slot)
+                .user(user)
+                .role(role)
+                .build();
+        timeSlotUserRepository.save(tsu);
+        slot.addTimeSlotUser(tsu);
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/entity/User.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/entity/User.java
@@ -2,6 +2,7 @@ package KUSITMS.WITHUS.domain.user.user.entity;
 
 import KUSITMS.WITHUS.domain.application.comment.entity.Comment;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
+import KUSITMS.WITHUS.domain.recruitment.position.entity.Position;
 import KUSITMS.WITHUS.domain.user.user.enumerate.ProfileColor;
 import KUSITMS.WITHUS.domain.user.userOrganization.entity.UserOrganization;
 import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
@@ -105,5 +106,11 @@ public class User extends BaseEntity {
     public void addUserOrganizationRole(UserOrganizationRole role) {
         this.userOrganizationRoles.add(role);
         role.associateUser(this);
+    }
+
+    public boolean hasMatchingRole(Position position) {
+        return this.userOrganizationRoles.stream()
+                .map(UserOrganizationRole::getOrganizationRole)
+                .anyMatch(role1 -> role1.getName().equalsIgnoreCase(position.getName()));
     }
 }


### PR DESCRIPTION
### ✨ Related Issue
- #131 
---

### 📌 Task Details
- [x] TT 재생성시 기존 TT 삭제
- [x] 관리자는 TT에 배정된 지원자의 코멘트 전체를 확인할 수 있도록 (현재는 본인이 작성한 코멘트만 확인 가능)
- [x] 면접관 자동 배정 기능

---

### 💬 Review Requirements (Optional)
- 면접관 자동 배정 로직
전체 배정 안 되더라도 가능한 사람 최대한 배정되는 형식입니다. 그리고 service에 메서드가 두툼해졌는데, 이거 기능 수정하면서 분리해볼게여
