### PR TITLE
🐛 TimeSlot 기능 수정

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
@@ -521,4 +521,16 @@ public class ApplicationResponseDTO {
         }
     }
 
+    @Schema(description = "지원자 요약 정보 응답 DTO")
+    public record Applicant(
+            @Schema(description = "지원서 ID") Long id,
+            @Schema(description = "지원자 이름") String name
+    ) {
+        public static Applicant from(Application application) {
+            return new Applicant(
+                    application.getId(),
+                    application.getName()
+            );
+        }
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
@@ -17,5 +17,5 @@ public interface ApplicationRepository {
     List<Application> findAllById(List<Long> longs);
     List<Application> findDistinctByRecruitment_IdAndEvaluators_Evaluator_IdAndEvaluators_EvaluationType(Long recruitmentId, Long evaluatorId, EvaluationType evaluationType);
     Long countByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses);
-    List<Application> findForTimeSlotFilteredByUser(Long timeSlotId, Long requesterId);
+    List<Application> findForTimeSlot(Long timeSlotId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
@@ -11,11 +11,11 @@ public interface ApplicationRepository {
     Application save(Application application);
     void delete(Long id);
     List<Application> findPassedByRecruitment(Long recruitmentId);
-    List<Application> findByRecruitmentId(Long recruitmentId);
     List<Application> findByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses);
     List<Application> findByRecruitment_IdAndPosition_Id(Long recruitmentId, Long positionId);
     Long countByRecruitment_IdAndPosition_Id(Long recruitmentId, Long positionId);
     List<Application> findAllById(List<Long> longs);
     List<Application> findDistinctByRecruitment_IdAndEvaluators_Evaluator_IdAndEvaluators_EvaluationType(Long recruitmentId, Long evaluatorId, EvaluationType evaluationType);
     Long countByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses);
+    List<Application> findForTimeSlotFilteredByUser(Long timeSlotId, Long requesterId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
@@ -82,9 +82,9 @@ public class ApplicationRepositoryImpl implements ApplicationRepository {
     }
 
     @Override
-    public List<Application> findForTimeSlotFilteredByUser(Long timeSlotId, Long requesterId) {
+    public List<Application> findForTimeSlot(Long timeSlotId) {
         return queryFactory.selectFrom(application).distinct()
-                .join(application.timeSlot, timeSlot).fetchJoin()   // 필수
+                .join(application.timeSlot, timeSlot).fetchJoin()
                 .leftJoin(application.position, position).fetchJoin()
                 .leftJoin(application.user, user).fetchJoin()
                 .where(timeSlot.id.eq(timeSlotId))

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
@@ -12,6 +12,9 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static KUSITMS.WITHUS.domain.application.application.entity.QApplication.application;
+import static KUSITMS.WITHUS.domain.interview.timeslot.entity.QTimeSlot.timeSlot;
+import static KUSITMS.WITHUS.domain.recruitment.position.entity.QPosition.position;
+import static KUSITMS.WITHUS.domain.user.user.entity.QUser.user;
 
 
 @Repository
@@ -49,11 +52,6 @@ public class ApplicationRepositoryImpl implements ApplicationRepository {
     }
 
     @Override
-    public List<Application> findByRecruitmentId(Long recruitmentId) {
-        return applicationJpaRepository.findByRecruitmentId(recruitmentId);
-    }
-
-    @Override
     public List<Application> findByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses) {
         return applicationJpaRepository.findByRecruitmentIdAndStatusIn(recruitmentId, statuses);
     }
@@ -81,5 +79,16 @@ public class ApplicationRepositoryImpl implements ApplicationRepository {
     @Override
     public Long countByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses) {
         return applicationJpaRepository.countByRecruitmentIdAndStatusIn(recruitmentId, statuses);
+    }
+
+    @Override
+    public List<Application> findForTimeSlotFilteredByUser(Long timeSlotId, Long requesterId) {
+        return queryFactory.selectFrom(application).distinct()
+                .join(application.timeSlot, timeSlot).fetchJoin()   // 필수
+                .leftJoin(application.position, position).fetchJoin()
+                .leftJoin(application.user, user).fetchJoin()
+                .where(timeSlot.id.eq(timeSlotId))
+                .orderBy(application.createdAt.asc())
+                .fetch();
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/controller/TimeSlotController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/controller/TimeSlotController.java
@@ -9,7 +9,6 @@ import KUSITMS.WITHUS.global.common.annotation.CurrentUser;
 import KUSITMS.WITHUS.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,17 +31,16 @@ public class TimeSlotController {
     @GetMapping("/{timeSlotId}")
     @Operation(summary = "타임슬롯 조회", description = "특정 타임슬롯에 배정된 사용자/지원자 목록을 조회합니다.")
     public SuccessResponse<TimeSlotResponseDTO> getUsersByTimeSlot(
-            @PathVariable Long timeSlotId,
-            @CurrentUser User user
+            @PathVariable Long timeSlotId
     ) {
-        return SuccessResponse.ok(timeSlotService.getTimeSlotDetail(timeSlotId, user.getId()));
+        return SuccessResponse.ok(timeSlotService.getTimeSlotDetail(timeSlotId));
     }
 
     @PostMapping("/{timeSlotId}/applications")
     @Operation(summary = "타임 슬롯에 지원자 추가", description = "특정 타임 슬롯에 수동으로 지원자를 추가합니다.")
     public SuccessResponse<String> addApplicantToTimeSlot(
             @PathVariable Long timeSlotId,
-            @RequestBody @Valid TimeSlotRequestDTO.UpsertApplicant request
+            @RequestBody TimeSlotRequestDTO.UpsertApplicant request
     ) {
         timeSlotService.addApplicantToTimeSlot(timeSlotId, request.applicantIds());
         return SuccessResponse.ok("지원자가 타임슬롯에 추가되었습니다.");
@@ -52,7 +50,7 @@ public class TimeSlotController {
     @Operation(summary = "타임 슬롯 지원자 수정", description = "특정 타임 슬롯에 배정된 지원자의 정보를 수정합니다.")
     public SuccessResponse<String> updateApplicantInTimeSlot(
             @PathVariable Long timeSlotId,
-            @RequestBody @Valid TimeSlotRequestDTO.UpsertApplicant request
+            @RequestBody TimeSlotRequestDTO.UpsertApplicant request
     ) {
         timeSlotService.updateApplicantInTimeSlot(timeSlotId, request.applicantIds());
         return SuccessResponse.ok("지원자 정보가 수정되었습니다.");

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/controller/TimeSlotController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/controller/TimeSlotController.java
@@ -2,6 +2,7 @@ package KUSITMS.WITHUS.domain.interview.timeslot.controller;
 
 import KUSITMS.WITHUS.domain.application.application.dto.ApplicationResponseDTO;
 import KUSITMS.WITHUS.domain.interview.timeslot.dto.TimeSlotRequestDTO;
+import KUSITMS.WITHUS.domain.interview.timeslot.dto.TimeSlotResponseDTO;
 import KUSITMS.WITHUS.domain.interview.timeslot.service.TimeSlotService;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
 import KUSITMS.WITHUS.global.common.annotation.CurrentUser;
@@ -26,6 +27,15 @@ public class TimeSlotController {
     @Operation(summary = "타임 슬롯에 배정된 지원자 조회", description = "해당 타임 슬롯 ID에 배정된 모든 지원자의 상세 정보를 조회합니다.")
     public SuccessResponse<List<ApplicationResponseDTO.DetailForTimeSlot>> getApplicationsByTimeSlot(@PathVariable Long timeSlotId, @CurrentUser User user) {
         return SuccessResponse.ok(timeSlotService.getApplicationsByTimeSlotFilteredByUser(timeSlotId, user.getId()));
+    }
+
+    @GetMapping("/{timeSlotId}")
+    @Operation(summary = "타임슬롯 조회", description = "특정 타임슬롯에 배정된 사용자/지원자 목록을 조회합니다.")
+    public SuccessResponse<TimeSlotResponseDTO> getUsersByTimeSlot(
+            @PathVariable Long timeSlotId,
+            @CurrentUser User user
+    ) {
+        return SuccessResponse.ok(timeSlotService.getTimeSlotDetail(timeSlotId, user.getId()));
     }
 
     @PostMapping("/{timeSlotId}/applications")

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/controller/TimeSlotController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/controller/TimeSlotController.java
@@ -1,17 +1,16 @@
 package KUSITMS.WITHUS.domain.interview.timeslot.controller;
 
 import KUSITMS.WITHUS.domain.application.application.dto.ApplicationResponseDTO;
+import KUSITMS.WITHUS.domain.interview.timeslot.dto.TimeSlotRequestDTO;
 import KUSITMS.WITHUS.domain.interview.timeslot.service.TimeSlotService;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
 import KUSITMS.WITHUS.global.common.annotation.CurrentUser;
 import KUSITMS.WITHUS.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,5 +26,25 @@ public class TimeSlotController {
     @Operation(summary = "타임 슬롯에 배정된 지원자 조회", description = "해당 타임 슬롯 ID에 배정된 모든 지원자의 상세 정보를 조회합니다.")
     public SuccessResponse<List<ApplicationResponseDTO.DetailForTimeSlot>> getApplicationsByTimeSlot(@PathVariable Long timeSlotId, @CurrentUser User user) {
         return SuccessResponse.ok(timeSlotService.getApplicationsByTimeSlotFilteredByUser(timeSlotId, user.getId()));
+    }
+
+    @PostMapping("/{timeSlotId}/applications")
+    @Operation(summary = "타임 슬롯에 지원자 추가", description = "특정 타임 슬롯에 수동으로 지원자를 추가합니다.")
+    public SuccessResponse<String> addApplicantToTimeSlot(
+            @PathVariable Long timeSlotId,
+            @RequestBody @Valid TimeSlotRequestDTO.UpsertApplicant request
+    ) {
+        timeSlotService.addApplicantToTimeSlot(timeSlotId, request.applicantIds());
+        return SuccessResponse.ok("지원자가 타임슬롯에 추가되었습니다.");
+    }
+
+    @PatchMapping("/{timeSlotId}/applications")
+    @Operation(summary = "타임 슬롯 지원자 수정", description = "특정 타임 슬롯에 배정된 지원자의 정보를 수정합니다.")
+    public SuccessResponse<String> updateApplicantInTimeSlot(
+            @PathVariable Long timeSlotId,
+            @RequestBody @Valid TimeSlotRequestDTO.UpsertApplicant request
+    ) {
+        timeSlotService.updateApplicantInTimeSlot(timeSlotId, request.applicantIds());
+        return SuccessResponse.ok("지원자 정보가 수정되었습니다.");
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/Applicant.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/Applicant.java
@@ -1,0 +1,6 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.dto;
+
+import KUSITMS.WITHUS.domain.application.application.entity.Application;
+
+public record Applicant(Long applicationId, Application application) {
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/TimeSlotRequestDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/TimeSlotRequestDTO.java
@@ -1,0 +1,15 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "TimeSlot 관련 요청 DTO")
+public class TimeSlotRequestDTO {
+
+    @Schema(description = "TimeSlot에 지원자 추가 요청 DTO")
+    public record UpsertApplicant(
+            @Schema(description = "추가할 지원자 ID 목록", example = "[1, 2]") List<Long> applicantIds
+    ) {}
+}
+

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/TimeSlotResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/TimeSlotResponseDTO.java
@@ -1,0 +1,38 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.dto;
+
+import KUSITMS.WITHUS.domain.application.application.dto.ApplicationResponseDTO;
+import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.dto.TimeSlotUserResponseDTO;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
+import KUSITMS.WITHUS.domain.recruitment.position.dto.PositionResponseDTO;
+import KUSITMS.WITHUS.global.common.annotation.TimeFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Schema(description = "타임슬롯 응답 DTO")
+public record TimeSlotResponseDTO(
+        @Schema(description = "타임슬롯 ID") Long timeSlotId,
+        @Schema(description = "시작 시각") @TimeFormat LocalTime startAt,
+        @Schema(description = "종료 시각") @TimeFormat LocalTime endAt,
+        @Schema(description = "포지션") PositionResponseDTO.Detail position,
+
+        @Schema(description = "배정된 사용자 목록") List<TimeSlotUserResponseDTO> users,
+        @Schema(description = "배정된 지원자 목록") List<ApplicationResponseDTO.Applicant> applicants
+) {
+    public static TimeSlotResponseDTO from(
+            TimeSlot slot,
+            List<TimeSlotUser> users,
+            List<ApplicationResponseDTO.Applicant> applicants
+    ) {
+        return new TimeSlotResponseDTO(
+                slot.getId(),
+                slot.getStartTime(),
+                slot.getEndTime(),
+                PositionResponseDTO.Detail.from(slot.getPosition()),
+                users.stream().map(TimeSlotUserResponseDTO::from).toList(),
+                applicants
+        );
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/entity/TimeSlot.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/entity/TimeSlot.java
@@ -58,4 +58,9 @@ public class TimeSlot extends BaseEntity {
         this.timeSlotUsers.add(timeSlotUser);
         timeSlotUser.assignTimeSlot(this);
     }
+
+    public void addApplication(Application applicant) {
+        this.applications.add(applicant);
+        applicant.assignTimeSlot(this);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotService.java
@@ -1,6 +1,7 @@
 package KUSITMS.WITHUS.domain.interview.timeslot.service;
 
 import KUSITMS.WITHUS.domain.application.application.dto.ApplicationResponseDTO;
+import KUSITMS.WITHUS.domain.interview.timeslot.dto.TimeSlotResponseDTO;
 
 import java.util.List;
 
@@ -8,4 +9,5 @@ public interface TimeSlotService {
     List<ApplicationResponseDTO.DetailForTimeSlot> getApplicationsByTimeSlotFilteredByUser(Long timeSlotId, Long currentUserId);
     void addApplicantToTimeSlot(Long timeSlotId, List<Long> applicantIds);
     void updateApplicantInTimeSlot(Long timeSlotId, List<Long> applicantIds);
+    TimeSlotResponseDTO getTimeSlotDetail(Long timeSlotId, Long id);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotService.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface TimeSlotService {
     List<ApplicationResponseDTO.DetailForTimeSlot> getApplicationsByTimeSlotFilteredByUser(Long timeSlotId, Long currentUserId);
+    void addApplicantToTimeSlot(Long timeSlotId, List<Long> applicantIds);
+    void updateApplicantInTimeSlot(Long timeSlotId, List<Long> applicantIds);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotService.java
@@ -9,5 +9,5 @@ public interface TimeSlotService {
     List<ApplicationResponseDTO.DetailForTimeSlot> getApplicationsByTimeSlotFilteredByUser(Long timeSlotId, Long currentUserId);
     void addApplicantToTimeSlot(Long timeSlotId, List<Long> applicantIds);
     void updateApplicantInTimeSlot(Long timeSlotId, List<Long> applicantIds);
-    TimeSlotResponseDTO getTimeSlotDetail(Long timeSlotId, Long id);
+    TimeSlotResponseDTO getTimeSlotDetail(Long timeSlotId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
@@ -9,8 +9,11 @@ import KUSITMS.WITHUS.domain.application.comment.repository.CommentRepository;
 import KUSITMS.WITHUS.domain.evaluation.evaluation.entity.Evaluation;
 import KUSITMS.WITHUS.domain.evaluation.evaluation.repository.EvaluationRepository;
 import KUSITMS.WITHUS.domain.interview.timeslot.dto.Applicant;
+import KUSITMS.WITHUS.domain.interview.timeslot.dto.TimeSlotResponseDTO;
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
 import KUSITMS.WITHUS.domain.interview.timeslot.repository.TimeSlotRepository;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.repository.TimeSlotUserRepository;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
 import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
 import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
@@ -27,6 +30,7 @@ import java.util.stream.Collectors;
 public class TimeSlotServiceImpl implements TimeSlotService {
 
     private final TimeSlotRepository timeSlotRepository;
+    private final TimeSlotUserRepository timeSlotUserRepository;
     private final EvaluationRepository evaluationRepository;
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
@@ -103,4 +107,17 @@ public class TimeSlotServiceImpl implements TimeSlotService {
         timeSlotRepository.save(timeSlot);
     }
 
+    @Override
+    public TimeSlotResponseDTO getTimeSlotDetail(Long timeSlotId, Long requesterId) {
+        TimeSlot slot = timeSlotRepository.getById(timeSlotId);
+
+        List<TimeSlotUser> users = timeSlotUserRepository.findByTimeSlotId(timeSlotId);
+
+        List<Application> apps = applicationRepository.findForTimeSlotFilteredByUser(timeSlotId, requesterId);
+        List<ApplicationResponseDTO.Applicant> applicants = apps.stream()
+                        .map(ApplicationResponseDTO.Applicant::from)
+                        .toList();
+
+        return TimeSlotResponseDTO.from(slot, users, applicants);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
@@ -108,12 +108,12 @@ public class TimeSlotServiceImpl implements TimeSlotService {
     }
 
     @Override
-    public TimeSlotResponseDTO getTimeSlotDetail(Long timeSlotId, Long requesterId) {
+    public TimeSlotResponseDTO getTimeSlotDetail(Long timeSlotId) {
         TimeSlot slot = timeSlotRepository.getById(timeSlotId);
 
         List<TimeSlotUser> users = timeSlotUserRepository.findByTimeSlotId(timeSlotId);
 
-        List<Application> apps = applicationRepository.findForTimeSlotFilteredByUser(timeSlotId, requesterId);
+        List<Application> apps = applicationRepository.findForTimeSlot(timeSlotId);
         List<ApplicationResponseDTO.Applicant> applicants = apps.stream()
                         .map(ApplicationResponseDTO.Applicant::from)
                         .toList();

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
@@ -1,11 +1,14 @@
 package KUSITMS.WITHUS.domain.interview.timeslot.service;
 
 import KUSITMS.WITHUS.domain.application.application.dto.ApplicationResponseDTO;
+import KUSITMS.WITHUS.domain.application.application.entity.Application;
+import KUSITMS.WITHUS.domain.application.application.repository.ApplicationRepository;
 import KUSITMS.WITHUS.domain.application.comment.entity.Comment;
 import KUSITMS.WITHUS.domain.application.comment.enumerate.CommentType;
 import KUSITMS.WITHUS.domain.application.comment.repository.CommentRepository;
 import KUSITMS.WITHUS.domain.evaluation.evaluation.entity.Evaluation;
 import KUSITMS.WITHUS.domain.evaluation.evaluation.repository.EvaluationRepository;
+import KUSITMS.WITHUS.domain.interview.timeslot.dto.Applicant;
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
 import KUSITMS.WITHUS.domain.interview.timeslot.repository.TimeSlotRepository;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,6 +30,7 @@ public class TimeSlotServiceImpl implements TimeSlotService {
     private final EvaluationRepository evaluationRepository;
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
+    private final ApplicationRepository applicationRepository;
 
 
     @Override
@@ -51,4 +56,51 @@ public class TimeSlotServiceImpl implements TimeSlotService {
                 })
                 .toList();
     }
+
+    @Override
+    @Transactional
+    public void addApplicantToTimeSlot(Long timeSlotId, List<Long> applicantIds) {
+        TimeSlot timeSlot = timeSlotRepository.getById(timeSlotId);
+        List<Application> applicants = applicationRepository.findAllById(applicantIds);
+
+        for (Application applicant : applicants) {
+            timeSlot.addApplication(applicant);
+        }
+
+        timeSlotRepository.save(timeSlot);
+    }
+
+    @Override
+    @Transactional
+    public void updateApplicantInTimeSlot(Long timeSlotId, List<Long> applicantIds) {
+        TimeSlot timeSlot = timeSlotRepository.getById(timeSlotId);
+
+        // 현재 배정된 지원자 정보
+        List<Applicant> existingApplications = timeSlot.getApplications().stream()
+                .map(application -> new Applicant(application.getId(), application))
+                .toList();
+
+        // 삭제 대상 처리
+        timeSlot.getApplications().removeIf(application -> {
+            boolean shouldRemove = !applicantIds.contains(application.getId());
+            if (shouldRemove) {
+                application.assignTimeSlot(null);
+            }
+            return shouldRemove;
+        });
+
+        // 추가 대상 처리
+        List<Long> toAdd = applicantIds.stream()
+                .filter(id -> existingApplications.stream().noneMatch(record -> record.applicationId().equals(id)))
+                .collect(Collectors.toList());
+
+        // Time Slot에 추가
+        List<Application> applicationsToAdd = applicationRepository.findAllById(toAdd);
+        for (Application application : applicationsToAdd) {
+            timeSlot.addApplication(application);
+        }
+
+        timeSlotRepository.save(timeSlot);
+    }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/AssignmentRecorder.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/AssignmentRecorder.java
@@ -1,0 +1,30 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.service.util;
+
+import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
+import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.repository.TimeSlotUserRepository;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AssignmentRecorder {
+
+    private final TimeSlotUserRepository timeSlotUserRepository;
+
+    /**
+     * TimeSlot에 사용자 배정
+     */
+    public void assign(final TimeSlot slot, final User user, final InterviewRole role) {
+        final TimeSlotUser timeSlotUser = TimeSlotUser.builder()
+                .timeSlot(slot)
+                .user(user)
+                .role(role)
+                .build();
+
+        slot.addTimeSlotUser(timeSlotUser);
+        timeSlotUserRepository.save(timeSlotUser);
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/calendar/BusyCalendar.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/calendar/BusyCalendar.java
@@ -1,0 +1,8 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.service.util.calendar;
+
+import java.time.LocalDateTime;
+
+public interface BusyCalendar {
+    boolean isBusy(Long userId, LocalDateTime start, LocalDateTime end);
+    void markBusy(Long userId, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/calendar/InMemoryBusyCalendar.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/calendar/InMemoryBusyCalendar.java
@@ -26,15 +26,18 @@ public class InMemoryBusyCalendar implements BusyCalendar {
     }
 
     /** 주어진 시간대에 이미 바쁜지 확인 */
+    @Override
     public boolean isBusy(Long userId, LocalDateTime start, LocalDateTime end) {
-        for (Range range : busy.get(userId)) {
+        List<Range> ranges = busy.computeIfAbsent(userId, k -> new ArrayList<>());
+        for (Range range : ranges) {
             if (overlap(range.start, range.end, start, end)) return true;
         }
         return false;
     }
 
     /** 배정 후 바쁜 시간대 추가 */
+    @Override
     public void markBusy(Long userId, LocalDateTime start, LocalDateTime end) {
-        busy.get(userId).add(new Range(start, end));
+        busy.computeIfAbsent(userId, k -> new ArrayList<>()).add(new Range(start, end));
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/calendar/InMemoryBusyCalendar.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/calendar/InMemoryBusyCalendar.java
@@ -1,0 +1,40 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.service.util.calendar;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+/**
+ * 유저별 바쁜 시간대를 메모리에 보관하여 동시간대 중복 배정을 방지하기 위한 경량 캘린더
+ */
+public class InMemoryBusyCalendar implements BusyCalendar {
+
+    /** 단일 사용자 바쁜 구간 표현 */
+        private record Range(LocalDateTime start, LocalDateTime end) {
+    }
+
+    private final Map<Long, List<Range>> busy = new HashMap<>();
+
+    /** 초기화 - 후보 사용자 ID를 키로 등록 */
+    public InMemoryBusyCalendar(Collection<Long> userIds) {
+        for (Long userId : userIds) busy.put(userId, new ArrayList<>());
+    }
+
+    /** 시간 구간 겹침 여부 */
+    private static boolean overlap(LocalDateTime start1, LocalDateTime end1,
+                                   LocalDateTime start2, LocalDateTime end2) {
+        return start1.isBefore(end2) && start2.isBefore(end1);
+    }
+
+    /** 주어진 시간대에 이미 바쁜지 확인 */
+    public boolean isBusy(Long userId, LocalDateTime start, LocalDateTime end) {
+        for (Range range : busy.get(userId)) {
+            if (overlap(range.start, range.end, start, end)) return true;
+        }
+        return false;
+    }
+
+    /** 배정 후 바쁜 시간대 추가 */
+    public void markBusy(Long userId, LocalDateTime start, LocalDateTime end) {
+        busy.get(userId).add(new Range(start, end));
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/candidate/CandidateIndex.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/candidate/CandidateIndex.java
@@ -1,0 +1,42 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.service.util.candidate;
+
+import KUSITMS.WITHUS.domain.interview.interviewAvailabiliy.entity.InterviewerAvailability;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class CandidateIndex {
+    private final Map<Long, Set<LocalDateTime>> availableTimes;
+    private final Map<Long, User> userMap;
+
+    /**
+     * 가용시간 인덱스 구성
+     */
+    public static CandidateIndex of(final List<InterviewerAvailability> availabilities,
+                                    final UserRepository userRepository) {
+
+        final Map<Long, Set<LocalDateTime>> times = availabilities.stream()
+                .collect(Collectors.groupingBy(
+                        a -> a.getUser().getId(),
+                        Collectors.mapping(
+                                InterviewerAvailability::getAvailableTime,
+                                Collectors.toCollection(HashSet::new)
+                        )
+                ));
+
+        final Map<Long, User> users = userRepository.findAllById(times.keySet().stream().toList())
+                .stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        return new CandidateIndex(times, users);
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/candidate/CandidateSelector.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/candidate/CandidateSelector.java
@@ -1,0 +1,70 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.service.util.candidate;
+
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.calendar.BusyCalendar;
+import KUSITMS.WITHUS.domain.recruitment.position.entity.Position;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CandidateSelector {
+
+    /** 1차 후보 - 시간/포지션 일치 */
+    public List<Long> preliminaryCandidates(final LocalDateTime slotStart,
+                                            final Position slotPosition,
+                                            final CandidateIndex index) {
+        final List<Long> prelim = new ArrayList<>();
+
+        for (final Map.Entry<Long, Set<LocalDateTime>> entry : index.getAvailableTimes().entrySet()) {
+            final Long userId = entry.getKey();
+            final boolean hasTime = entry.getValue().contains(slotStart);
+
+            if (!hasTime) {
+                log.debug("[FAIL] userId={} 는 시간 불일치", userId);
+                continue;
+            }
+
+            final User user = index.getUserMap().get(userId);
+            final boolean matchRole = (slotPosition == null) || user.hasMatchingRole(slotPosition);
+
+            if (!matchRole) {
+                log.debug("[FAIL] userId={} ({}) 포지션 불일치", userId, user.getName());
+                log.debug("유저 역할 목록: {}", user.getUserOrganizationRoles().stream()
+                        .map(r -> r.getOrganizationRole().getName())
+                        .toList());
+                continue;
+            }
+
+            prelim.add(userId);
+        }
+        return prelim;
+    }
+
+    /** 2차 후보 - 동시간대 중복 배정 제거 */
+    public List<Long> feasibleCandidates(final List<Long> prelim,
+                                         final LocalDateTime slotStart,
+                                         final LocalDateTime slotEnd,
+                                         final CandidateIndex index,
+                                         final BusyCalendar busyCalendar) {
+        final List<Long> feasible = new ArrayList<>();
+
+        for (final Long userId : prelim) {
+            if (busyCalendar.isBusy(userId, slotStart, slotEnd)) {
+                final User user = index.getUserMap().get(userId);
+                log.debug("[FAIL] userId={} ({}) 이미 배정됨", userId, user.getName());
+                continue;
+            }
+            feasible.add(userId);
+        }
+        return feasible;
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/selection/ordering/ScarcityFirstSlotOrderingStrategy.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/selection/ordering/ScarcityFirstSlotOrderingStrategy.java
@@ -1,0 +1,58 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.service.util.selection.ordering;
+
+import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.candidate.CandidateIndex;
+import KUSITMS.WITHUS.domain.recruitment.position.entity.Position;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class ScarcityFirstSlotOrderingStrategy implements SlotOrderingStrategy {
+
+    /**
+     * 후보 수가 적은 슬롯부터 정렬
+     * 동률이면 날짜 - 시간 - 방 이름 순으로 정렬
+     */
+    @Override
+    public List<TimeSlot> order(final List<TimeSlot> timeSlots, final CandidateIndex index) {
+        return timeSlots.stream()
+                .sorted(Comparator
+                        .comparingInt((TimeSlot slot) -> countEligibleCandidates(slot, index))
+                        .thenComparing(TimeSlot::getDate)
+                        .thenComparing(TimeSlot::getStartTime)
+                        .thenComparing(TimeSlot::getRoomName))
+                .toList();
+    }
+
+    /** 주어진 슬롯에 배정 가능한 사용자 수를 계산 */
+    private int countEligibleCandidates(final TimeSlot slot, final CandidateIndex index) {
+        final LocalDateTime slotStart = slot.getDate().atTime(slot.getStartTime());
+        final Position slotPosition = slot.getPosition();
+
+        int eligibleCount = 0;
+
+        for (Map.Entry<Long, Set<LocalDateTime>> entry : index.getAvailableTimes().entrySet()) {
+            final Long userId = entry.getKey();
+            final Set<LocalDateTime> availableAt = entry.getValue();
+
+            // 해당 시각 가능 여부
+            if (!availableAt.contains(slotStart)) continue;
+
+            // 사용자 객체 조회
+            final User candidate = index.getUserMap().get(userId);
+            if (candidate == null) continue;
+
+            // 포지션 매칭 - 포지션이 없으면 통과
+            final boolean positionMatches = (slotPosition == null) || candidate.hasMatchingRole(slotPosition);
+            if (positionMatches) eligibleCount++;
+        }
+
+        return eligibleCount;
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/selection/ordering/SlotOrderingStrategy.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/selection/ordering/SlotOrderingStrategy.java
@@ -1,0 +1,10 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.service.util.selection.ordering;
+
+import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.candidate.CandidateIndex;
+
+import java.util.List;
+
+public interface SlotOrderingStrategy {
+    List<TimeSlot> order(List<TimeSlot> timeSlots, CandidateIndex index);
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/selection/policy/FairnessPolicy.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/selection/policy/FairnessPolicy.java
@@ -1,0 +1,9 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.service.util.selection.policy;
+
+import java.util.Comparator;
+import java.util.Map;
+
+public interface FairnessPolicy {
+    /** 공평 분배 정책 */
+    Comparator<Long> comparator(Map<Long, Integer> assignedCount);
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/selection/policy/LeastAssignedFirstPolicy.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/util/selection/policy/LeastAssignedFirstPolicy.java
@@ -1,0 +1,18 @@
+package KUSITMS.WITHUS.domain.interview.timeslot.service.util.selection.policy;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.Map;
+
+@Component
+public class LeastAssignedFirstPolicy implements FairnessPolicy {
+
+    /** 현재까지 적게 배정된 사람 우선, 동률이면 userId 오름차순 */
+    @Override
+    public Comparator<Long> comparator(final Map<Long, Integer> assignedCount) {
+        return Comparator
+                .comparingInt((Long userId) -> assignedCount.get(userId))
+                .thenComparingLong(Long::longValue);
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/service/TimeSlotUserServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/service/TimeSlotUserServiceImpl.java
@@ -7,6 +7,13 @@ import KUSITMS.WITHUS.domain.interview.interviewAvailabiliy.entity.InterviewerAv
 import KUSITMS.WITHUS.domain.interview.interviewAvailabiliy.repository.InterviewerAvailabilityRepository;
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
 import KUSITMS.WITHUS.domain.interview.timeslot.repository.TimeSlotRepository;
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.*;
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.calendar.BusyCalendar;
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.calendar.InMemoryBusyCalendar;
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.candidate.CandidateIndex;
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.candidate.CandidateSelector;
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.selection.policy.FairnessPolicy;
+import KUSITMS.WITHUS.domain.interview.timeslot.service.util.selection.ordering.SlotOrderingStrategy;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.repository.TimeSlotUserRepository;
 import KUSITMS.WITHUS.domain.recruitment.position.entity.Position;
@@ -33,6 +40,11 @@ public class TimeSlotUserServiceImpl implements TimeSlotUserService {
     private final TimeSlotUserRepository timeSlotUserRepository;
     private final InterviewRepository interviewRepository;
     private final InterviewerAvailabilityRepository interviewerAvailabilityRepository;
+
+    private final SlotOrderingStrategy slotOrderingStrategy;
+    private final CandidateSelector candidateSelector;
+    private final FairnessPolicy fairnessPolicy;
+    private final AssignmentRecorder assignmentRecorder;
 
     @Override
     @Transactional
@@ -96,90 +108,91 @@ public class TimeSlotUserServiceImpl implements TimeSlotUserService {
         }
     }
 
+    /**
+     * 면접관 자동 배정 오케스트레이션
+     */
     @Override
     @Transactional
-    public void assignInterviewers(Long interviewId) {
-        // 기존 면접관 배정 삭제
+    public void assignInterviewers(final Long interviewId) {
         timeSlotUserRepository.deleteByInterviewIdAndRole(interviewId, InterviewRole.INTERVIEWER);
 
-        Interview interview = interviewRepository.getById(interviewId);
-        List<TimeSlot> timeSlots = timeSlotRepository.findByInterviewId(interviewId);
-        List<InterviewerAvailability> availabilities = interviewerAvailabilityRepository.findByInterviewId(interviewId);
+        final Interview interview = interviewRepository.getById(interviewId);
+        final List<TimeSlot> timeSlots = timeSlotRepository.findByInterviewId(interviewId);
+        final List<InterviewerAvailability> availabilities = interviewerAvailabilityRepository.findByInterviewId(interviewId);
 
         log.info("[1] 타임슬롯 수: {}", timeSlots.size());
         log.info("[2] 인터뷰어 가능 시간 제출 수: {}", availabilities.size());
 
-        Map<Long, List<LocalDateTime>> userAvailableTimes = availabilities.stream()
-                .collect(Collectors.groupingBy(
-                        a -> a.getUser().getId(),
-                        Collectors.mapping(InterviewerAvailability::getAvailableTime, Collectors.toList())
-                ));
+        final CandidateIndex index = CandidateIndex.of(availabilities, userRepository);
 
-        log.info("[3] 가능한 유저 수: {}", userAvailableTimes.size());
+        log.info("[3] 가능한 유저 수: {}", index.getAvailableTimes().size());
 
-        Map<Long, User> userMap = userRepository.findAllById(new ArrayList<>(userAvailableTimes.keySet()))
-                .stream()
-                .collect(Collectors.toMap(User::getId, Function.identity()));
+        final Map<Long, Integer> assignedCount = initAssignedCount(index.getUserMap().keySet());
+        final BusyCalendar busyCalendar = new InMemoryBusyCalendar(index.getUserMap().keySet());
 
-        Set<Long> usedUsers = new HashSet<>();
+        final List<TimeSlot> orderedSlots = slotOrderingStrategy.order(timeSlots, index);
 
-        for (TimeSlot slot : timeSlots) {
-            LocalDateTime slotTime = slot.getDate().atTime(slot.getStartTime());
-            Position slotPosition = slot.getPosition();
-
-            log.info("[4] 타임슬롯 ID: {} / 시간: {} / 포지션: {}",
-                    slot.getId(), slotTime, slotPosition != null ? slotPosition.getName() : "null");
-
-            List<Long> assignableUserIds = userAvailableTimes.entrySet().stream()
-                    .filter(e -> {
-                        boolean hasTime = e.getValue().contains(slotTime);
-                        if (!hasTime) {
-                            log.debug("[FAIL] userId={} 는 시간 불일치", e.getKey());
-                        }
-                        return hasTime;
-                    })
-                    .map(Map.Entry::getKey)
-                    .filter(userId -> {
-                        User user = userMap.get(userId);
-                        boolean alreadyUsed = usedUsers.contains(userId);
-                        boolean matchRole = slotPosition == null || user.hasMatchingRole(slotPosition);
-
-                        if (alreadyUsed) {
-                            log.debug("[FAIL] userId={} ({}) 이미 배정됨", userId, user.getName());
-                            return false;
-                        }
-                        if (!matchRole) {
-                            log.debug("[FAIL] userId={} ({}) 포지션 불일치", userId, user.getName());
-                            log.debug("유저 역할 목록: {}", user.getUserOrganizationRoles().stream()
-                                    .map(r -> r.getOrganizationRole().getName())
-                                    .toList());
-                        }
-
-                        return matchRole;
-                    })
-                    .limit(interview.getInterviewerPerSlot())
-                    .toList();
-
-            for (Long userId : assignableUserIds) {
-                User user = userMap.get(userId);
-                assignToSlot(slot, user, InterviewRole.INTERVIEWER);
-                usedUsers.add(userId);
-                log.info("[SUCCESS] 배정: userId={} ({})", userId, user.getName());
-            }
-
-            if (assignableUserIds.isEmpty()) {
-                log.warn("[WARN] 배정 가능한 운영진 없음 (timeSlotId={})", slot.getId());
-            }
+        final int needPerSlot = resolveNeedPerSlot(interview);
+        for (final TimeSlot slot : orderedSlots) {
+            processSlot(slot, needPerSlot, index, assignedCount, busyCalendar);
         }
     }
-    
-    private void assignToSlot(TimeSlot slot, User user, InterviewRole role) {
-        TimeSlotUser tsu = TimeSlotUser.builder()
-                .timeSlot(slot)
-                .user(user)
-                .role(role)
-                .build();
-        timeSlotUserRepository.save(tsu);
-        slot.addTimeSlotUser(tsu);
+
+    /** 공평 분배 카운터 초기화 */
+    private Map<Long, Integer> initAssignedCount(final Collection<Long> userIds) {
+        final Map<Long, Integer> assignedCount = new HashMap<>();
+        for (final Long uid : userIds) assignedCount.put(uid, 0);
+        return assignedCount;
+    }
+
+    /** 슬롯당 필요 면접관 수 */
+    private int resolveNeedPerSlot(final Interview interview) {
+        final Integer perSlot = interview.getInterviewerPerSlot();
+        return (perSlot != null && perSlot > 0) ? perSlot : 1;
+    }
+
+    /**
+     * 단일 슬롯 배정 처리
+     */
+    private void processSlot(final TimeSlot slot,
+                             final int needPerSlot,
+                             final CandidateIndex index,
+                             final Map<Long, Integer> assignedCount,
+                             final BusyCalendar busyCalendar) {
+
+        final LocalDateTime slotStart = slot.getDate().atTime(slot.getStartTime());
+        final LocalDateTime slotEnd   = slot.getDate().atTime(slot.getEndTime());
+        final Position slotPosition   = slot.getPosition();
+
+        log.info("[4] 타임슬롯 ID: {} / 시간: {} / 포지션: {}",
+                slot.getId(), slotStart, slotPosition != null ? slotPosition.getName() : "null");
+
+        // 시간/포지션 일치 후보
+        final List<Long> prelim = candidateSelector.preliminaryCandidates(slotStart, slotPosition, index);
+
+        // 동시간대 겹침 제거
+        final List<Long> feasible = candidateSelector.feasibleCandidates(prelim, slotStart, slotEnd, index, busyCalendar);
+
+        // 공평 분배(덜 배정된 사용자 먼저)
+        final List<Long> sorted = feasible.stream()
+                .sorted(fairnessPolicy.comparator(assignedCount))
+                .toList();
+
+        int assignedInThisSlot = 0;
+        for (final Long uid : sorted) {
+            if (assignedInThisSlot >= needPerSlot) break;
+
+            final User user = index.getUserMap().get(uid);
+            assignmentRecorder.assign(slot, user, InterviewRole.INTERVIEWER);
+            busyCalendar.markBusy(uid, slotStart, slotEnd);
+            assignedCount.merge(uid, 1, Integer::sum);
+
+            log.info("[SUCCESS] 배정: userId={} ({})", uid, user.getName());
+            assignedInThisSlot++;
+        }
+
+        if (assignedInThisSlot == 0) {
+            log.warn("[WARN] 배정 가능한 운영진 없음 (timeSlotId={})", slot.getId());
+        }
     }
 }


### PR DESCRIPTION
### ✨ Related Issue
- #140 
---

### 📌 Task Details
- [x] 현재 타임슬롯에 사용자들만 수동으로 배정 가능한데 지원자까지 가능하도록 확장 (검색, 배정 등)
- [x] 한 사용자가 여러 타임슬롯에 중복 배정될 수 있도록 수정
- [x] TimeSlot 사용자 조회 API에서 배정된 사용자 + 지원자까지 보이도록 수정

---

### 💬 Review Requirements (Optional)
- 사용자(운영진) 자동 배정 로직이 또 복잡해서 최대한 메서드, 클래스 나누고 확장성(다른 구현체로 교체하는 상황) 생각하고 구현했는데, 이거 한번 확인해주세요
- 디렉토리 구조가 큰 틀을 바꾸지 않는 이상 깔끔하게 안 돼서 service.util 안에 몰아 넣었는데, 좋은 의견 있으면 주시면 감사하겠습니다 !
- 추가 피드백 있다면 편하게 주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 타임슬롯 상세 조회 추가: 시간, 포지션, 배정자 및 지원자 목록을 통합 제공.
  * 타임슬롯 대상 지원자 관리 API 추가: 지원자 일괄 추가·수정 기능 제공.
  * 경량 지원자 요약 응답 추가로 리스트 표현 간소화.

* **개선**
  * 면접관 자동 배정 고도화: 가용성·역할 검사, 충돌 방지, 공정성 기준으로 우선순위 지정 및 배정 품질 향상.
  * 시간 기반 지원자 조회 흐름 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->