### PR TITLE
♻️ 초대코드를 생성하고, 조회한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### VS Code ###
 .vscode/
+/txt
+/withus-ssh.pem
+/src/main/resources/application-argo.yml

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -1,0 +1,25 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: withus-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"   # 빈 비밀번호 허용
+      MYSQL_DATABASE: withus
+      TZ: Asia/Seoul
+    command:
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+      --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql-data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+  redis:
+    image: redis:latest
+    container_name: withus-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+volumes:
+  mysql-data:

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organization/controller/OrganizationController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organization/controller/OrganizationController.java
@@ -107,4 +107,23 @@ public class OrganizationController {
         List<OrganizationResponseDTO.Summary> dtos = organizationService.getMyOrganizations(currentUser.getId());
         return SuccessResponse.ok(dtos);
     }
+
+    @GetMapping("/{organizationId}/code")
+    @Operation(summary = "초대 코드 조회", description = "조직 ID를 기반으로 초대 코드를 생성하거나 기존 코드를 조회합니다.")
+    public SuccessResponse<OrganizationResponseDTO.InviteCode> generateOrGetInviteCode(
+            @CurrentUser User currentUser,
+            @PathVariable Long organizationId
+    ) {
+        OrganizationResponseDTO.InviteCode inviteCode = organizationService.generateOrGetInviteCode(currentUser.getId(), organizationId);
+        return SuccessResponse.ok(inviteCode);
+    }
+
+    @GetMapping("/inviteCode/exchange")
+    @Operation(summary = "초대 코드로 조직 조회", description = "초대 코드를 기반으로 조직의 상세 정보를 조회합니다.")
+    public SuccessResponse<OrganizationResponseDTO.Detail> getByInviteCode(
+            @RequestParam String inviteCode
+    ) {
+        OrganizationResponseDTO.Detail organizationDetail = organizationService.getByInviteCode(inviteCode);
+        return SuccessResponse.ok(organizationDetail);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organization/dto/OrganizationResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organization/dto/OrganizationResponseDTO.java
@@ -72,4 +72,19 @@ public class OrganizationResponseDTO {
         }
     }
 
+    @Schema(description = "조직 초대 코드 조회 응답 DTO")
+    public record InviteCode(
+            Long id,
+            String name,
+            String inviteCode
+    ) {
+        public static InviteCode from(Organization organization) {
+            return new InviteCode(
+                    organization.getId(),
+                    organization.getName(),
+                    organization.getInviteCode()
+            );
+        }
+    }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organization/entity/Organization.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organization/entity/Organization.java
@@ -25,6 +25,9 @@ public class Organization extends BaseEntity {
     @Column(name = "NAME", nullable = false)
     private String name;
 
+    @Column(name = "INVTIE_CODE", unique = true)
+    private String inviteCode;
+
     @Builder.Default
     @OneToMany(mappedBy = "organization", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserOrganization> userOrganizations = new ArrayList<>();
@@ -50,5 +53,9 @@ public class Organization extends BaseEntity {
     public void addOrganizationRole(OrganizationRole role) {
         this.organizationRoles.add(role);
         role.associateOrganization(this);
+    }
+
+    public void setInviteCode(String inviteCode) {
+        this.inviteCode = inviteCode;
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organization/repository/OrganizationJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organization/repository/OrganizationJpaRepository.java
@@ -4,8 +4,11 @@ import KUSITMS.WITHUS.domain.organization.organization.entity.Organization;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrganizationJpaRepository extends JpaRepository<Organization, Long> {
     List<Organization> findByNameContaining(String keyword);
     boolean existsByName(String name);
+
+    Optional<Organization> findByInviteCode(String inviteCode);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organization/repository/OrganizationRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organization/repository/OrganizationRepository.java
@@ -3,6 +3,7 @@ package KUSITMS.WITHUS.domain.organization.organization.repository;
 import KUSITMS.WITHUS.domain.organization.organization.entity.Organization;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrganizationRepository {
     Organization getById(Long id);
@@ -11,4 +12,5 @@ public interface OrganizationRepository {
     void delete(Long id);
     List<Organization> findByNameContaining(String keyword);
     boolean existsByName(String name);
+    Optional<Organization> findByInviteCode(String inviteCode);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organization/repository/OrganizationRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organization/repository/OrganizationRepositoryImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -44,4 +45,7 @@ public class OrganizationRepositoryImpl implements OrganizationRepository {
     public boolean existsByName(String name) {
         return organizationJpaRepository.existsByName(name);
     }
+
+    @Override
+    public Optional<Organization> findByInviteCode(String inviteCode) { return organizationJpaRepository.findByInviteCode(inviteCode); }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organization/service/OrganizationService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organization/service/OrganizationService.java
@@ -14,4 +14,6 @@ public interface OrganizationService {
     List<OrganizationResponseDTO.Summary> getAll();
     List<Organization> search(String keyword);
     List<OrganizationResponseDTO.Summary> getMyOrganizations(Long userId);
+    OrganizationResponseDTO.InviteCode generateOrGetInviteCode(Long userId, Long organizationId);
+    OrganizationResponseDTO.Detail getByInviteCode(String inviteCode);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organization/service/OrganizationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organization/service/OrganizationServiceImpl.java
@@ -6,12 +6,17 @@ import KUSITMS.WITHUS.domain.organization.organization.entity.Organization;
 import KUSITMS.WITHUS.domain.organization.organization.repository.OrganizationRepository;
 import KUSITMS.WITHUS.domain.user.userOrganization.entity.UserOrganization;
 import KUSITMS.WITHUS.domain.user.userOrganization.repository.UserOrganizationRepository;
+import KUSITMS.WITHUS.global.exception.CustomException;
+import KUSITMS.WITHUS.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Random;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -103,4 +108,55 @@ public class OrganizationServiceImpl implements OrganizationService {
                 .toList();
     }
 
+    /**
+     * 조직의 초대 코드를 생성하거나 기존 코드를 반환합니다.
+     * @param userId 요청을 보낸 사용자의 ID
+     * @param organizationId 초대 코드를 생성하거나 조회할 조직의 ID
+     * @return 조직의 초대 코드 반환
+     * @throws CustomException 사용자가 조직에 속하지 않은 경우 FORBIDDEN 예외 발생
+     */
+    @Transactional
+    public OrganizationResponseDTO.InviteCode generateOrGetInviteCode(Long userId, Long organizationId) {
+        List<Long> userOrganizationIds = userOrganizationRepository.findOrganizationIdsByUserId(userId);
+
+        if (!userOrganizationIds.contains(organizationId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        Organization organization = organizationRepository.getById(organizationId);
+
+        if (organization.getInviteCode() != null && !organization.getInviteCode().isEmpty()) {
+            log.info("기존 초대코드 반환: {}", organization.getInviteCode());
+            return OrganizationResponseDTO.InviteCode.from(organization);
+        }
+
+        String inviteCode = generateRandomCode();
+        log.info("새로운 초대코드 생성: {}", inviteCode);
+        organization.setInviteCode(inviteCode);
+
+        return OrganizationResponseDTO.InviteCode.from(organizationRepository.save(organization));
+    }
+
+    private String generateRandomCode() {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";
+        StringBuilder sb = new StringBuilder();
+        Random random = new Random();
+        for (int i = 0; i < 6; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 초대 코드로 조직 단건 조회
+     * @param inviteCode 조회할 조직의 초대 코드 입력
+     * @return 조직 상세 정보 반환
+     */
+    @Override
+    public OrganizationResponseDTO.Detail getByInviteCode(String inviteCode) {
+        Organization organization = organizationRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new CustomException(ErrorCode.ORGANIZATION_NOT_EXIST));
+
+        return OrganizationResponseDTO.Detail.from(organization);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/global/config/SecurityConfig.java
+++ b/src/main/java/KUSITMS/WITHUS/global/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
             "/api/v1/applications",
             "/api/v1/recruitments/slug/**",
             "/api/v1/organizations/invite/accept",
+            "/api/v1/organizations/inviteCode/exchange",
     };
 
     private final RefreshTokenCacheUtil refreshTokenCacheUtil;

--- a/src/test/java/KUSITMS/WITHUS/mock/repository/FakeOrganizationRepository.java
+++ b/src/test/java/KUSITMS/WITHUS/mock/repository/FakeOrganizationRepository.java
@@ -8,6 +8,7 @@ import KUSITMS.WITHUS.global.exception.ErrorCode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -63,5 +64,12 @@ public class FakeOrganizationRepository implements OrganizationRepository {
     public boolean existsByName(String name) {
         return data.stream()
                 .anyMatch(org -> org.getName().equals(name));
+    }
+
+    @Override
+    public Optional<Organization> findByInviteCode(String inviteCode) {
+        return data.stream()
+                .filter(org -> org.getInviteCode().equals(inviteCode))
+                .findFirst();
     }
 }


### PR DESCRIPTION
### ✨ Related Issue
- #145 
---

### 📌 Task Details
- [x] 조직(Organization) 초대 코드 생성/조회 기능 구현
- [x] 초대 코드가 없는 경우 새로 생성하고, 있는 경우 기존 코드 반환하는 로직 수정
- [x] 초대 코드 생성 메서드에 로깅 추가
- [x] Docker Compose 파일에 Redis 서비스 추가
---
1. generateOrGetInviteCode 메서드 구현
조직의 초대 코드가 없으면 새로 생성
조직의 초대 코드가 이미 있으면 기존 코드 반환
초대 코드 존재 여부 확인 로직 수정 (null 체크 및 isEmpty 체크)
2. Docker 환경 구성
MySQL과 Redis 컨테이너 설정 추가

### 💬 Review Requirements (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 조직 초대 코드 생성/재발급 및 조회 API 추가
  - 초대 코드를 사용한 조직 상세 조회 API 추가 (인증 없이 접근 가능)
- Chores
  - 로컬 개발용 MySQL·Redis docker-compose 구성 추가
  - 불필요 파일 무시를 위한 .gitignore 항목 보강
- Tests
  - 테스트 더블에서 초대 코드 기반 조직 조회 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->