### PR TITLE
♻️ 회원가입 시 이메일 인증으로 변경한다

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/user/service/UserServiceImpl.java
@@ -68,8 +68,8 @@ public class UserServiceImpl implements UserService {
             throw new CustomException(ErrorCode.ORGANIZATION_ALREADY_EXIST);
         }
 
-        // 휴대폰 번호 인증 여부 확인
-        checkPhoneVerifiedBeforeJoin(phoneNumber);
+        // 이메일 인증 여부 확인
+        checkEmailVerifiedBeforeJoin(email);
 
         // Organization 생성 및 저장
         Organization organization = organizationRepository.save(
@@ -128,8 +128,8 @@ public class UserServiceImpl implements UserService {
             throw new CustomException(ErrorCode.USER_ALREADY_EXIST);
         }
 
-        // 휴대폰 번호 인증 여부 확인
-        checkPhoneVerifiedBeforeJoin(phoneNumber);
+        // 이메일 인증 여부 확인
+        checkEmailVerifiedBeforeJoin(email);
 
         // 존재하는 조직 Id로 조회
         Organization organization = organizationRepository.getById(organizationId);
@@ -213,6 +213,17 @@ public class UserServiceImpl implements UserService {
      */
     public void checkPhoneVerifiedBeforeJoin(String phoneNumber) {
         if (!verificationCache.isVerified(phoneNumber)) {
+            throw new CustomException(ErrorCode.NOT_VERIFIED);
+        }
+    }
+
+    /**
+     * 회원가입 전 이메일 인증 여부 확인
+     * @param email 확인할 이메일 주소
+     * @throws CustomException 이메일 인증이 완료되지 않은 경우 예외를 발생시킵니다.
+     */
+    public void checkEmailVerifiedBeforeJoin(String email) {
+        if (!verificationCache.isVerified(email)) {
             throw new CustomException(ErrorCode.NOT_VERIFIED);
         }
     }

--- a/src/main/java/KUSITMS/WITHUS/global/auth/service/AuthServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/global/auth/service/AuthServiceImpl.java
@@ -99,21 +99,13 @@ public class AuthServiceImpl implements AuthService {
      * 이메일 인증 요청
      * @param name 사용자의 이름
      * @param email 사용자의 이메일
-     * @throws CustomException 사용자를 찾을 수 없거나, 사용자의 이름이 일치하지 않는 경우 예외를 발생시킵니다.
      */
     @Override
     public void requestEmailVerification(String name, String email) {
-        User user = userRepository.getByEmail(email);
-        if (!user.getName().equals(name)) {
-            throw new CustomException(ErrorCode.USER_NOT_EXIST);
-        }
-
-        String code = String.valueOf(new Random().nextInt(900000) + 100000);
-
+        String code = generateCode();
         verificationCache.saveCode(email, code, CODE_TTL);
 
         sendEmail(email, code);
-
     }
 
     /**


### PR DESCRIPTION
### ✨ Related Issue

기존에 회원가입 시 휴대폰 인증하던 것에서, 이메일 인증하는 로직으로 변경

---

### 📌 Task Details
- [x] 이메일 인증 시 회원 검증 로직 삭제
- [x] 회원가입 시 이메일 인증으로 변경

---

### 💬 Review Requirements (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원가입 시 휴대폰 인증 대신 이메일 인증을 사용하도록 변경했습니다.
  - 이메일 인증 코드 요청에서 이름 확인 절차를 제거해 요청이 더 간단하고 빠릅니다.
  - 6자리 인증 코드 발급을 표준화해 인증 메일 발송의 신뢰성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->