### PR TITLE
fix: 테스트코드 휴대폰 인증에서 이메일 인증으로 변경 #147

### DIFF
--- a/src/test/java/KUSITMS/WITHUS/domain/user/user/service/UserServiceImplTest.java
+++ b/src/test/java/KUSITMS/WITHUS/domain/user/user/service/UserServiceImplTest.java
@@ -33,7 +33,7 @@ class UserServiceImplTest {
                         .build()
         );
 
-        testContainer.verificationCache.markVerified("01012345678", Duration.ofMinutes(3));
+        testContainer.verificationCache.markVerified("test@example.com", Duration.ofMinutes(3));
 
         UserRequestDTO.UserJoin userJoinRequest = new UserRequestDTO.UserJoin(
                 "김재관",

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/interview/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/interview/interview/controller/InterviewControllerTest.java
@@ -63,7 +63,7 @@ class InterviewControllerTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        verificationCache.markVerified(testPhone, Duration.ofMinutes(3));
+        verificationCache.markVerified(testMail, Duration.ofMinutes(3));
         createTestUser();
         accessToken = testAuthHelper.loginAndGetAccessToken(testMail, testPassword);
     }

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/user/user/controller/UserControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/user/user/controller/UserControllerTest.java
@@ -74,7 +74,6 @@ class UserControllerTest {
 
         userRepository.save(testUser);
 
-        verificationCache.markVerified(testPhone, Duration.ofMinutes(3));
         verificationCache.markVerified(testMail, Duration.ofMinutes(3));
     }
 
@@ -90,7 +89,7 @@ class UserControllerTest {
         );
 
         String requestBody = objectMapper.writeValueAsString(request);
-        verificationCache.markVerified("01012345678", Duration.ofMinutes(3));
+        verificationCache.markVerified("admin@example.com", Duration.ofMinutes(3));
 
         mockMvc.perform(post("/api/v1/users/join/admin")
                         .contentType(APPLICATION_JSON)
@@ -113,7 +112,6 @@ class UserControllerTest {
         );
 
         String requestBody = objectMapper.writeValueAsString(joinReq);
-        verificationCache.markVerified("01012345678", Duration.ofMinutes(3));
         verificationCache.markVerified("test@example.com", Duration.ofMinutes(3));
 
         mockMvc.perform(post("/api/v1/users/join/user")
@@ -146,11 +144,14 @@ class UserControllerTest {
                 "01012345678"
         );
 
+        String requestBody = objectMapper.writeValueAsString(req);
+        verificationCache.markVerified("test2@example.com", Duration.ofMinutes(3));
+
         // When
         // Then
         mockMvc.perform(post("/api/v1/users/join/user")
                         .contentType(APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(req)))
+                        .content(requestBody))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("성공하였습니다."))
                 .andExpect(jsonPath("$.success").value(true));


### PR DESCRIPTION
### ✨ Related Issue

테스트코드 쪽 사용자 회원가입 로직을 기존 휴대폰 인증 방법에서 이메일 인증으로 바꾸지 않았어서 깃 액션이 안 돌아가고 있었습니다

---

### 📌 Task Details
- [x] UserServiceImplTest 쪽 사용자 생성 로직 수정
- [x] InterviewControllerTest 쪽 사용자 생성 로직 수정
- [x] UserControllerTest 쪽 사용자 생성 로직 수정

---

### 💬 Review Requirements (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 테스트
  - 인증 검증 대상이 전화번호에서 이메일로 변경되었습니다(테스트 입력값만 변경). 테스트 흐름·성공·실패·예외 처리에는 영향이 없으며 제품 기능, 성능, 보안, 공개 API, 빌드/배포에는 영향이 없습니다. -> 뭐래 테스트 성공 처리할려고 해둔건데
<!-- end of auto-generated comment: release notes by coderabbit.ai -->