### PR TITLE
🐛 조직 관리 API 수정

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/controller/OrganizationRoleController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/controller/OrganizationRoleController.java
@@ -71,4 +71,14 @@ public class OrganizationRoleController {
         organizationRoleService.updateRole(organizationId, roleId, request.name(), request.color());
         return SuccessResponse.ok("조직 내 역할 수정에 성공했습니다.");
     }
+
+    @DeleteMapping("/{organizationId}/roles/{roleId}")
+    @Operation(summary = "조직 역할 삭제", description = "배정 관계를 모두 제거한 뒤 조직 역할을 삭제합니다.")
+    public SuccessResponse<String> deleteRole(
+            @PathVariable Long organizationId,
+            @PathVariable Long roleId
+    ) {
+        organizationRoleService.deleteRole(organizationId, roleId);
+        return SuccessResponse.ok("조직 역할 삭제에 성공했습니다.");
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/repository/OrganizationRoleRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/repository/OrganizationRoleRepository.java
@@ -11,4 +11,5 @@ public interface OrganizationRoleRepository {
     List<OrganizationRole> findAllById(List<Long> roleIds);
     List<OrganizationRole> findByOrganizationIdAndKeyword(Long organizationId, String keyword);
     boolean existsByOrganizationIdAndNameExceptId(Long organizationId, String name, Long excludedId);
+    void deleteById(Long roleId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/repository/OrganizationRoleRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/repository/OrganizationRoleRepositoryImpl.java
@@ -67,6 +67,11 @@ public class OrganizationRoleRepositoryImpl implements OrganizationRoleRepositor
                 .fetchFirst() != null;
     }
 
+    @Override
+    public void deleteById(Long roleId) {
+        organizationRoleJpaRepository.deleteById(roleId);
+    }
+
     private BooleanExpression keywordCondition(String keyword) {
         if (keyword == null || keyword.isBlank()) {
             return null;

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleService.java
@@ -10,4 +10,5 @@ public interface OrganizationRoleService {
     OrganizationRoleResponseDTO.Detail createRole(Long organizationId, String name, String color);
     OrganizationRoleResponseDTO.DetailForOrganization getOrganizationRoles(Long organizationId, String keyword);
     void updateRole(Long organizationId, Long roleId, String name, String color);
+    void deleteRole(Long organizationId, Long roleId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
@@ -28,37 +28,35 @@ public class OrganizationRoleServiceImpl implements OrganizationRoleService {
     private final OrganizationRoleRepository organizationRoleRepository;
     private final UserOrganizationRoleRepository userOrganizationRoleRepository;
 
+    /**
+     * 운영진에게 역할 일괄 추가/제거
+     * @param organizationId 역할이 속한 조직 ID
+     * @param userId 역할을 부여할 사용자 ID
+     * @param roleIds 부여할 역할 ID 리스트
+     * @return 부여된 역할 정보 반환
+     */
     @Override
     @Transactional
     public List<OrganizationRoleResponseDTO.DetailForUser> assignRoleToUser(Long organizationId, Long userId, List<Long> roleIds) {
+        final List<Long> requestedRoleIds = normalizeRequestedIds(roleIds);
+
         User user = userRepository.getById(userId);
-        List<OrganizationRole> roles = organizationRoleRepository.findAllById(roleIds);
+        List<UserOrganizationRole> currentLinksInOrg = getCurrentLinksInOrg(user, organizationId);
+        Set<Long> currentRoleIds = toRoleIdSet(currentLinksInOrg);
 
-        List<OrganizationRoleResponseDTO.DetailForUser> result = new ArrayList<>();
+        Map<Long, OrganizationRole> requestedRoleMapInOrg = loadRequestedRoleMapInOrg(organizationId, requestedRoleIds);
+        Set<Long> requestedValidIds = requestedRoleMapInOrg.keySet();
 
-        for (OrganizationRole role : roles) {
-            if (!role.getOrganization().getId().equals(organizationId)) {
-                continue; // 조직 ID 불일치
-            }
+        Set<Long> toAddIds = calcToAddIds(currentRoleIds, requestedValidIds);
+        Set<Long> toRemoveIds = calcToRemoveIds(currentRoleIds, requestedValidIds);
 
-            boolean alreadyAssigned = user.getUserOrganizationRoles().stream()
-                    .anyMatch(r -> r.getOrganizationRole().getId().equals(role.getId()));
+        removeLinks(user, currentLinksInOrg, toRemoveIds);
+        addLinks(user, requestedRoleMapInOrg, toAddIds);
 
-            if (alreadyAssigned) {
-                continue; // 중복 역할
-            }
-
-            UserOrganizationRole userOrgRole = UserOrganizationRole.assign(user, role);
-
-            user.addUserOrganizationRole(userOrgRole);
-            role.addUserOrganizationRole(userOrgRole);
-
-            userOrganizationRoleRepository.save(userOrgRole);
-
-            result.add(OrganizationRoleResponseDTO.DetailForUser.from(userOrgRole));
-        }
-
-        return result;
+        return user.getUserOrganizationRoles().stream()
+                .filter(uor -> uor.getOrganizationRole().getOrganization().getId().equals(organizationId))
+                .map(OrganizationRoleResponseDTO.DetailForUser::from)
+                .toList();
     }
 
     /**
@@ -236,5 +234,68 @@ public class OrganizationRoleServiceImpl implements OrganizationRoleService {
         );
 
         return new ArrayList<>(resultMap.values());
+    }
+
+    private List<Long> normalizeRequestedIds(List<Long> roleIds) {
+        return (roleIds == null) ? Collections.emptyList() : roleIds.stream().distinct().toList();
+    }
+
+    private List<UserOrganizationRole> getCurrentLinksInOrg(User user, Long organizationId) {
+        return user.getUserOrganizationRoles().stream()
+                .filter(uor -> uor.getOrganizationRole() != null
+                        && uor.getOrganizationRole().getOrganization().getId().equals(organizationId))
+                .toList();
+    }
+
+    private Set<Long> toRoleIdSet(List<UserOrganizationRole> links) {
+        return links.stream()
+                .map(uor -> uor.getOrganizationRole().getId())
+                .collect(Collectors.toSet());
+    }
+
+    private Map<Long, OrganizationRole> loadRequestedRoleMapInOrg(Long organizationId, List<Long> requestedRoleIds) {
+        if (requestedRoleIds.isEmpty()) return Collections.emptyMap();
+        List<OrganizationRole> requestedRoles = organizationRoleRepository.findAllById(requestedRoleIds);
+        return requestedRoles.stream()
+                .filter(r -> r.getOrganization().getId().equals(organizationId))
+                .collect(Collectors.toMap(OrganizationRole::getId, r -> r));
+    }
+
+    private Set<Long> calcToAddIds(Set<Long> currentRoleIds, Set<Long> requestedValidIds) {
+        Set<Long> toAdd = new HashSet<>(requestedValidIds);
+        toAdd.removeAll(currentRoleIds);
+        return toAdd;
+    }
+
+    private Set<Long> calcToRemoveIds(Set<Long> currentRoleIds, Set<Long> requestedValidIds) {
+        Set<Long> toRemove = new HashSet<>(currentRoleIds);
+        toRemove.removeAll(requestedValidIds);
+        return toRemove;
+    }
+
+    private void removeLinks(User user, List<UserOrganizationRole> currentLinksInOrg, Set<Long> toRemoveIds) {
+        if (toRemoveIds.isEmpty()) return;
+
+        List<UserOrganizationRole> toRemoveLinks = currentLinksInOrg.stream()
+                .filter(link -> toRemoveIds.contains(link.getOrganizationRole().getId()))
+                .toList();
+
+        userOrganizationRoleRepository.deleteAll(toRemoveLinks);
+        user.getUserOrganizationRoles().removeAll(toRemoveLinks);
+        toRemoveLinks.forEach(link -> link.getOrganizationRole().getUserOrganizationRoles().remove(link));
+    }
+
+    private void addLinks(User user, Map<Long, OrganizationRole> requestedRoleMapInOrg, Set<Long> toAddIds) {
+        if (toAddIds.isEmpty()) return;
+
+        List<UserOrganizationRole> toAddLinks = new ArrayList<>();
+        for (Long addId : toAddIds) {
+            OrganizationRole role = requestedRoleMapInOrg.get(addId);
+            UserOrganizationRole link = UserOrganizationRole.assign(user, role);
+            user.addUserOrganizationRole(link);
+            role.addUserOrganizationRole(link);
+            toAddLinks.add(link);
+        }
+        userOrganizationRoleRepository.saveAll(toAddLinks);
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
@@ -254,11 +254,27 @@ public class OrganizationRoleServiceImpl implements OrganizationRoleService {
     }
 
     private Map<Long, OrganizationRole> loadRequestedRoleMapInOrg(Long organizationId, List<Long> requestedRoleIds) {
-        if (requestedRoleIds.isEmpty()) return Collections.emptyMap();
+        if (requestedRoleIds == null || requestedRoleIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Set<Long> requestedIdSet = new HashSet<>(requestedRoleIds);
         List<OrganizationRole> requestedRoles = organizationRoleRepository.findAllById(requestedRoleIds);
-        return requestedRoles.stream()
+
+        if (requestedRoles.size() != requestedIdSet.size()) {
+            throw new CustomException(ErrorCode.ORGANIZATION_ROLE_NOT_EXIST);
+        }
+
+        Map<Long, OrganizationRole> roleMap = requestedRoles.stream()
                 .filter(r -> r.getOrganization().getId().equals(organizationId))
                 .collect(Collectors.toMap(OrganizationRole::getId, r -> r));
+
+        // 요청한 모든 ID가 동일 조직에 속해야 함
+        if (roleMap.size() != requestedIdSet.size()) {
+            throw new CustomException(ErrorCode.ORGANIZATION_ROLE_ORG_MISMATCH);
+        }
+
+        return roleMap;
     }
 
     private Set<Long> calcToAddIds(Set<Long> currentRoleIds, Set<Long> requestedValidIds) {

--- a/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/organization/organizationRole/service/OrganizationRoleServiceImpl.java
@@ -148,6 +148,25 @@ public class OrganizationRoleServiceImpl implements OrganizationRoleService {
         role.update(name, color);
     }
 
+    /**
+     * 역할 삭제
+     * @param organizationId 삭제할 역할이 속한 조직 ID
+     * @param roleId 삭제할 역할 ID
+     */
+    @Override
+    @Transactional
+    public void deleteRole(Long organizationId, Long roleId) {
+        OrganizationRole role = organizationRoleRepository.getById(roleId);
+
+        // 조직 일치 검증
+        if (!role.getOrganization().getId().equals(organizationId)) {
+            throw new CustomException(ErrorCode.ORGANIZATION_ROLE_ORG_MISMATCH);
+        }
+
+        userOrganizationRoleRepository.deleteByOrganizationRoleId(roleId);
+        organizationRoleRepository.deleteById(roleId);
+    }
+
     private OrganizationRole getValidatedRole(Long organizationId, Long roleId) {
         OrganizationRole role = organizationRoleRepository.getById(roleId);
         if (!role.getOrganization().getId().equals(organizationId)) {

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleJpaRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface UserOrganizationRoleJpaRepository extends JpaRepository<UserOrganizationRole, Long> {
     List<UserOrganizationRole> findAllByOrganizationRole_Id(Long organizationRoleId);
+    void deleteByOrganizationRoleId(Long roleId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleJpaRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface UserOrganizationRoleJpaRepository extends JpaRepository<UserOrganizationRole, Long> {
     List<UserOrganizationRole> findAllByOrganizationRole_Id(Long organizationRoleId);
-    void deleteByOrganizationRoleId(Long roleId);
+    void deleteByOrganizationRole_Id(Long roleId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepository.java
@@ -9,4 +9,5 @@ public interface UserOrganizationRoleRepository {
     void deleteAll(List<UserOrganizationRole> userOrganizationRoles);
     void saveAll(List<UserOrganizationRole> userOrganizationRoles);
     List<UserOrganizationRole> findAllByOrganizationRole_Id(Long organizationRoleId);
+    void deleteByOrganizationRoleId(Long roleId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepositoryImpl.java
@@ -31,4 +31,9 @@ public class UserOrganizationRoleRepositoryImpl implements UserOrganizationRoleR
     public List<UserOrganizationRole> findAllByOrganizationRole_Id(Long organizationRoleId) {
         return userOrganizationRoleJpaRepository.findAllByOrganizationRole_Id(organizationRoleId);
     }
+
+    @Override
+    public void deleteByOrganizationRoleId(Long roleId) {
+        userOrganizationRoleJpaRepository.deleteByOrganizationRoleId(roleId);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/user/userOrganizationRole/repository/UserOrganizationRoleRepositoryImpl.java
@@ -34,6 +34,6 @@ public class UserOrganizationRoleRepositoryImpl implements UserOrganizationRoleR
 
     @Override
     public void deleteByOrganizationRoleId(Long roleId) {
-        userOrganizationRoleJpaRepository.deleteByOrganizationRoleId(roleId);
+        userOrganizationRoleJpaRepository.deleteByOrganizationRole_Id(roleId);
     }
 }


### PR DESCRIPTION
### ✨ Related Issue
- #152 
---

### 📌 Task Details
- [x] 조직 역할 삭제 API 추가
- [x] 조직 역할 부여 API에 부여 해지 기능 추가

---

### 💬 Review Requirements (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 조직 역할 삭제 API 추가(DELETE /{organizationId}/roles/{roleId}). 역할 삭제 시 해당 역할과 연결된 모든 사용자‑조직‑역할 관계도 함께 정리되며 성공 메시지를 반환합니다.
- 리팩터링
  - 사용자 역할 할당 로직을 차집합 기반 비교로 최적화하여 불필요한 반복을 제거하고, 추가/제거 동작을 명확히 분리해 성능과 안정성 개선.
  - 기존 엔드포인트와 응답 구조에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->