### PR TITLE
🐛 Fix: 3차 추가 요청사항을 수정한다

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/controller/AdminApplicationController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/controller/AdminApplicationController.java
@@ -156,6 +156,16 @@ public class AdminApplicationController {
         return SuccessResponse.ok("메일을 발송 요청을 보냈습니다.");
     }
 
+    @GetMapping("/recruitment/{recruitmentId}/search")
+    @Operation(summary = "공고 전체 지원자 검색", description = "메일/문자 발송용으로 공고의 전체 지원자를 이름 또는 이메일로 검색합니다.")
+    public SuccessResponse<List<ApplicationResponseDTO.ApplicantForMailSms>> searchApplicants(
+            @PathVariable Long recruitmentId,
+            @RequestParam(required = false) String keyword
+    ) {
+        List<ApplicationResponseDTO.ApplicantForMailSms> applicants = applicationService.searchApplicantsForMailSms(recruitmentId, keyword);
+        return SuccessResponse.ok(applicants);
+    }
+
     @PostMapping("/bulk-sms")
     @Operation(summary = "지원서 대상 다중 문자 발송", description = "복수의 수신자 전화번호와 메시지, 첨부파일(MMS)을 받아 일괄 발송합니다.")
     public SuccessResponse<String> sendBulkSms(

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/dto/ApplicationResponseDTO.java
@@ -555,4 +555,21 @@ public class ApplicationResponseDTO {
         }
     }
 
+    @Schema(description = "메일/문자 발송용 지원자 검색 응답 DTO")
+    public record ApplicantForMailSms(
+            @Schema(description = "지원서 ID", example = "1") Long applicationId,
+            @Schema(description = "지원자 이름", example = "홍길동") String name,
+            @Schema(description = "지원자 이메일", example = "hong@example.com") String email,
+            @Schema(description = "프로필 사진 URL", example = "https://example.com/profile.jpg") String profileImageUrl
+    ) {
+        public static ApplicantForMailSms from(Application application) {
+            return new ApplicantForMailSms(
+                    application.getId(),
+                    application.getName(),
+                    application.getEmail(),
+                    application.getImageUrl()
+            );
+        }
+    }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationJpaRepository.java
@@ -11,6 +11,7 @@ public interface ApplicationJpaRepository extends JpaRepository<Application, Lon
     List<Application> findByRecruitmentId(Long recruitmentId);
     List<Application> findByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses);
     List<Application> findByRecruitment_IdAndOrganizationRole_Id(Long recruitmentId, Long organizationRoleId);
+    List<Application> findByRecruitment_IdAndOrganizationRoleIsNull(Long recruitmentId);
     Long countByRecruitment_IdAndOrganizationRole_Id(Long recruitmentId, Long organizationRoleId);
     List<Application> findDistinctByRecruitment_IdAndEvaluators_Evaluator_IdAndEvaluators_EvaluationType(Long recruitmentId, Long evaluatorId, EvaluationType evaluationType);
     Long countByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses);

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
@@ -23,4 +23,5 @@ public interface ApplicationRepository {
     List<Application> findForTimeSlot(Long timeSlotId);
     Long findPreviousIdInRecruitment(Long recruitmentId, Long currentId);
     Long findNextIdInRecruitment(Long recruitmentId, Long currentId);
+    List<Application> findByRecruitmentIdAndNameOrEmail(Long recruitmentId, String keyword);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepository.java
@@ -14,6 +14,7 @@ public interface ApplicationRepository {
     List<Application> findPassedByRecruitment(Long recruitmentId);
     List<Application> findByRecruitmentIdAndStatusIn(Long recruitmentId, List<ApplicationStatus> statuses);
     List<Application> findByRecruitment_IdAndOrganizationRole_Id(Long recruitmentId, Long organizationRoleId);
+    List<Application> findByRecruitment_IdAndOrganizationRoleIsNull(Long recruitmentId);
     Long countByRecruitment_IdAndOrganizationRole_Id(Long recruitmentId, Long organizationRoleId);
     List<Application> findAllById(List<Long> longs);
     List<Application> findDistinctByRecruitment_IdAndEvaluators_Evaluator_IdAndEvaluators_EvaluationType(Long recruitmentId, Long evaluatorId, EvaluationType evaluationType);

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
@@ -63,6 +63,11 @@ public class ApplicationRepositoryImpl implements ApplicationRepository {
     }
 
     @Override
+    public List<Application> findByRecruitment_IdAndOrganizationRoleIsNull(Long recruitmentId) {
+        return applicationJpaRepository.findByRecruitment_IdAndOrganizationRoleIsNull(recruitmentId);
+    }
+
+    @Override
     public Long countByRecruitment_IdAndOrganizationRole_Id(Long recruitmentId, Long organizationRoleId) {
         return applicationJpaRepository.countByRecruitment_IdAndOrganizationRole_Id(recruitmentId, organizationRoleId);
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/repository/ApplicationRepositoryImpl.java
@@ -159,4 +159,25 @@ public class ApplicationRepositoryImpl implements ApplicationRepository {
                 )
                 .fetchOne();
     }
+
+    @Override
+    public List<Application> findByRecruitmentIdAndNameOrEmail(Long recruitmentId, String keyword) {
+        com.querydsl.core.types.dsl.BooleanExpression searchPredicate = null;
+        
+        // 키워드가 있으면 이름 또는 이메일로 검색, 없으면 전체 목록 조회
+        if (keyword != null && !keyword.isBlank()) {
+            String searchKeyword = keyword.trim();
+            searchPredicate = application.name.containsIgnoreCase(searchKeyword)
+                    .or(application.email.containsIgnoreCase(searchKeyword));
+        }
+
+        return queryFactory
+                .selectFrom(application)
+                .where(
+                        application.recruitment.id.eq(recruitmentId),
+                        searchPredicate  // null이면 검색 조건 무시되어 전체 목록 조회
+                )
+                .orderBy(application.name.asc())
+                .fetch();
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationService.java
@@ -28,4 +28,5 @@ public interface ApplicationService {
     boolean toggleAcquaintance(Long applicationId, Long userId);
     List<ApplicationResponseDTO.CandidateDTO> findTimeslotCandidates(Long recruitmentId, Long timeslotId, String query, boolean excludeCurrent);
     List<ApplicationResponseDTO.Detail> getAllDetailForExcel(Long recruitmentId, AdminStageFilter stage, AdminApplicationSortField sortBy, Sort.Direction direction, List<Long> organizationRoleIds, List<ApplicationStatus> statuses, String keyword, Long id);
+    List<ApplicationResponseDTO.ApplicantForMailSms> searchApplicantsForMailSms(Long recruitmentId, String keyword);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
@@ -206,10 +206,13 @@ public class ApplicationServiceImpl implements ApplicationService {
                 applicantAvailabilityRepository.findByApplicationId(id);
         List<Evaluation> evaluationList =
                 evaluationRepository.findEvaluationsForApplication(id);
+
+        // 공통 평가 기준(organizationRole이 null) + 해당 지원서의 organizationRole과 일치하는 평가 기준만 조회
         List<EvaluationCriteria> criteriaList =
-                evaluationCriteriaRepository.findByTypeAndRecruitment(
+                evaluationCriteriaRepository.findCommonAndByOrganizationRole(
+                        recruitmentId,
                         EvaluationType.DOCUMENT,
-                        recruitmentId
+                        app.getOrganizationRole()
                 );
 
         return assembler.toDetail(

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/ApplicationServiceImpl.java
@@ -469,6 +469,20 @@ public class ApplicationServiceImpl implements ApplicationService {
         return applicationRepository.findEligibleCandidates(recruitmentId, timeslotId, q, excludeCurrent);
     }
 
+    /**
+     * 메일/문자 발송용 지원자 검색
+     * @param recruitmentId 공고 ID
+     * @param keyword 검색어 (지원자 이름 또는 이메일)
+     * @return 지원자 목록 (지원서 ID, 이름, 이메일, 프로필 사진 URL)
+     */
+    @Override
+    public List<ApplicationResponseDTO.ApplicantForMailSms> searchApplicantsForMailSms(Long recruitmentId, String keyword) {
+        List<Application> applications = applicationRepository.findByRecruitmentIdAndNameOrEmail(recruitmentId, keyword);
+        return applications.stream()
+                .map(ApplicationResponseDTO.ApplicantForMailSms::from)
+                .toList();
+    }
+
     @Override
     public List<ApplicationResponseDTO.Detail> getAllDetailForExcel(
             Long recruitmentId,

--- a/src/main/java/KUSITMS/WITHUS/domain/application/application/service/evaluator/EvaluatorAssignmentService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/application/service/evaluator/EvaluatorAssignmentService.java
@@ -46,7 +46,9 @@ public class EvaluatorAssignmentService {
         // 요청 이력 dto -> 엔티티 매핑
         List<DistributionAssignment> assignments = request.assignments().stream()
                 .map(dto -> {
-                    OrganizationRole role = organizationRoleRepository.getById(dto.organizationRoleId());
+                    OrganizationRole role = dto.organizationRoleId() != null
+                            ? organizationRoleRepository.getById(dto.organizationRoleId())
+                            : null;
                     return DistributionAssignment.builder()
                             .organizationRole(role)
                             .evaluationType(dto.evaluationType())
@@ -77,9 +79,10 @@ public class EvaluatorAssignmentService {
                 throw new CustomException(ErrorCode.INSUFFICIENT_EVALUATORS);
             }
 
-            // 이 역할을 지원한 지원서 리스트
-            List<Application> apps = applicationRepository
-                    .findByRecruitment_IdAndOrganizationRole_Id(recruitmentId, part.organizationRoleId());
+            // 이 역할을 지원한 지원서 리스트 (organizationRoleId가 null이면 공통(역할 미지정) 지원서 조회)
+            List<Application> apps = part.organizationRoleId() == null
+                    ? applicationRepository.findByRecruitment_IdAndOrganizationRoleIsNull(recruitmentId)
+                    : applicationRepository.findByRecruitment_IdAndOrganizationRole_Id(recruitmentId, part.organizationRoleId());
 
             // 각 지원서마다 랜덤 n명 배정
             for (Application app : apps) {

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/dto/ApplicationEvaluatorRequestDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationEvaluator/dto/ApplicationEvaluatorRequestDTO.java
@@ -27,8 +27,7 @@ public class ApplicationEvaluatorRequestDTO {
     ) {
         @Schema(description = "지원 역할(OrganizationRole)별 평가 담당자 배정 정보")
         public record PartAssignment(
-                @Schema(description = "지원 역할(OrganizationRole) ID - 지원서가 지원한 역할", example = "4")
-                @NotNull
+                @Schema(description = "지원 역할(OrganizationRole) ID - null이면 공통(역할 미지정 지원서) 대상", example = "4")
                 Long organizationRoleId,
 
                 @Schema(description = "평가 담당자 Role(OrganizationRole) ID - 평가를 담당할 역할", example = "7")

--- a/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/dto/DistributionRequestResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/dto/DistributionRequestResponseDTO.java
@@ -41,7 +41,7 @@ public class DistributionRequestResponseDTO {
     ) {
         public static Assignment from(DistributionAssignment a) {
             return new Assignment(
-                    a.getOrganizationRole().getName(),
+                    a.getOrganizationRole() != null ? a.getOrganizationRole().getName() : "공통",
                     a.getEvaluationType(),
                     a.getCount()
             );

--- a/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/entity/DistributionAssignment.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/entity/DistributionAssignment.java
@@ -22,7 +22,7 @@ public class DistributionAssignment extends BaseEntity {
     private DistributionRequest request;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ORGANIZATION_ROLE_ID", nullable = false)
+    @JoinColumn(name = "ORGANIZATION_ROLE_ID")
     private OrganizationRole organizationRole;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/repository/DistributionRequestRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/distributionRequest/repository/DistributionRequestRepositoryImpl.java
@@ -1,18 +1,22 @@
 package KUSITMS.WITHUS.domain.application.distributionRequest.repository;
 
 import KUSITMS.WITHUS.domain.application.distributionRequest.entity.DistributionRequest;
-import KUSITMS.WITHUS.global.exception.CustomException;
-import KUSITMS.WITHUS.global.exception.ErrorCode;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+
+import static KUSITMS.WITHUS.domain.application.distributionRequest.entity.QDistributionRequest.distributionRequest;
+import static KUSITMS.WITHUS.domain.application.distributionRequest.entity.QDistributionAssignment.distributionAssignment;
+import static KUSITMS.WITHUS.domain.organization.organizationRole.entity.QOrganizationRole.organizationRole;
 
 @Repository
 @RequiredArgsConstructor
 public class DistributionRequestRepositoryImpl implements DistributionRequestRepository {
 
     private final DistributionRequestJpaRepository distributionRequestJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public DistributionRequest findTopByRecruitmentIdOrderByCreatedAtDesc(Long recruitmentId) {
@@ -31,7 +35,14 @@ public class DistributionRequestRepositoryImpl implements DistributionRequestRep
     }
 
     public List<DistributionRequest> findAllByRecruitmentIdOrderByCreatedAtDesc(Long recruitmentId) {
-        return distributionRequestJpaRepository.findAllByRecruitmentIdOrderByCreatedAtDesc(recruitmentId);
+        return queryFactory
+                .selectFrom(distributionRequest)
+                .distinct()
+                .leftJoin(distributionRequest.assignments, distributionAssignment).fetchJoin()
+                .leftJoin(distributionAssignment.organizationRole, organizationRole).fetchJoin()
+                .where(distributionRequest.recruitmentId.eq(recruitmentId))
+                .orderBy(distributionRequest.createdAt.desc())
+                .fetch();
     }
 
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/evaluation/evaluationCriteria/repository/EvaluationCriteriaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/evaluation/evaluationCriteria/repository/EvaluationCriteriaRepository.java
@@ -2,6 +2,7 @@ package KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.repository;
 
 import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.entity.EvaluationCriteria;
 import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationType;
+import KUSITMS.WITHUS.domain.organization.organizationRole.entity.OrganizationRole;
 
 import java.util.List;
 
@@ -10,5 +11,6 @@ public interface EvaluationCriteriaRepository {
     List<EvaluationCriteria> findByTypeAndRecruitment(EvaluationType type, Long recruitmentId);
     Long countByRecruitment_IdAndEvaluationType(Long recruitmentId, EvaluationType stage);
     List<EvaluationCriteria> findByRecruitment_IdAndEvaluationType(Long recruitmentId, EvaluationType stage);
+    List<EvaluationCriteria> findCommonAndByOrganizationRole(Long recruitmentId, EvaluationType type, OrganizationRole organizationRole);
     List<EvaluationCriteria> findAllById(List<Long> criteriaIds);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/evaluation/evaluationCriteria/repository/EvaluationCriteriaRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/evaluation/evaluationCriteria/repository/EvaluationCriteriaRepositoryImpl.java
@@ -2,18 +2,24 @@ package KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.repository;
 
 import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.entity.EvaluationCriteria;
 import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationType;
+import KUSITMS.WITHUS.domain.organization.organizationRole.entity.OrganizationRole;
 import KUSITMS.WITHUS.global.exception.CustomException;
 import KUSITMS.WITHUS.global.exception.ErrorCode;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+
+import static KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.entity.QEvaluationCriteria.evaluationCriteria;
 
 @Repository
 @RequiredArgsConstructor
 public class EvaluationCriteriaRepositoryImpl implements EvaluationCriteriaRepository {
 
     private final EvaluationCriteriaJpaRepository evaluationCriteriaJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public EvaluationCriteria getById(Long id) {
@@ -33,6 +39,23 @@ public class EvaluationCriteriaRepositoryImpl implements EvaluationCriteriaRepos
     @Override
     public List<EvaluationCriteria> findByRecruitment_IdAndEvaluationType(Long recruitmentId, EvaluationType stage) {
         return evaluationCriteriaJpaRepository.findByRecruitment_IdAndEvaluationType(recruitmentId, stage);
+    }
+
+    @Override
+    public List<EvaluationCriteria> findCommonAndByOrganizationRole(Long recruitmentId, EvaluationType type, OrganizationRole organizationRole) {
+        BooleanExpression roleFilter = organizationRole == null
+                ? evaluationCriteria.organizationRole.isNull()
+                : evaluationCriteria.organizationRole.isNull()
+                .or(evaluationCriteria.organizationRole.eq(organizationRole));
+
+        return queryFactory
+                .selectFrom(evaluationCriteria)
+                .where(
+                        evaluationCriteria.recruitment.id.eq(recruitmentId)
+                                .and(evaluationCriteria.evaluationType.eq(type))
+                                .and(roleFilter)
+                )
+                .fetch();
     }
 
     @Override

--- a/src/main/java/KUSITMS/WITHUS/domain/recruitment/position/dto/PositionResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/recruitment/position/dto/PositionResponseDTO.java
@@ -1,5 +1,6 @@
 package KUSITMS.WITHUS.domain.recruitment.position.dto;
 
+import KUSITMS.WITHUS.domain.organization.organizationRole.entity.OrganizationRole;
 import KUSITMS.WITHUS.domain.recruitment.position.entity.Position;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -21,6 +22,18 @@ public class PositionResponseDTO {
                     position.getId(),
                     position.getName(),
                     position.getColor()
+            );
+        }
+
+        public static Detail from(OrganizationRole organizationRole) {
+            if (organizationRole == null) {
+                return null;
+            }
+
+            return new Detail(
+                    organizationRole.getId(),
+                    organizationRole.getName(),
+                    organizationRole.getColor()
             );
         }
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/recruitment/position/service/PositionServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/recruitment/position/service/PositionServiceImpl.java
@@ -7,11 +7,19 @@ import KUSITMS.WITHUS.domain.recruitment.position.enumerate.PositionColor;
 import KUSITMS.WITHUS.domain.recruitment.position.repository.PositionRepository;
 import KUSITMS.WITHUS.domain.recruitment.recruitment.entity.Recruitment;
 import KUSITMS.WITHUS.domain.recruitment.recruitment.repository.RecruitmentRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static KUSITMS.WITHUS.domain.recruitment.recruitment.entity.QRecruitment.recruitment;
+import static KUSITMS.WITHUS.domain.recruitment.recruitmentOrganizationRole.entity.QRecruitmentOrganizationRole.recruitmentOrganizationRole;
+import static KUSITMS.WITHUS.domain.organization.organizationRole.entity.QOrganizationRole.organizationRole;
+
+import KUSITMS.WITHUS.global.exception.CustomException;
+import KUSITMS.WITHUS.global.exception.ErrorCode;
 
 @Service
 @Transactional(readOnly = true)
@@ -20,6 +28,7 @@ public class PositionServiceImpl implements PositionService {
 
     private final PositionRepository positionRepository;
     private final RecruitmentRepository recruitmentRepository;
+    private final JPAQueryFactory queryFactory;
 
     /**
      * 파트 생성
@@ -53,8 +62,20 @@ public class PositionServiceImpl implements PositionService {
 
     @Override
     public List<PositionResponseDTO.Detail> findAllByRecruitmentId(Long recruitmentId) {
-        return positionRepository.findAllByRecruitmentId(recruitmentId).stream()
-                .map(PositionResponseDTO.Detail::from)
+        // Recruitment의 RecruitmentOrganizationRole 리스트와 각각의 OrganizationRole을 함께 조회하기 위해 fetch join 사용
+        Recruitment found = queryFactory
+                .selectFrom(recruitment)
+                .leftJoin(recruitment.positions, recruitmentOrganizationRole).fetchJoin()
+                .leftJoin(recruitmentOrganizationRole.organizationRole, organizationRole).fetchJoin()
+                .where(recruitment.id.eq(recruitmentId))
+                .fetchOne();
+
+        if (found == null) {
+            throw new CustomException(ErrorCode.RECRUITMENT_NOT_EXIST);
+        }
+
+        return found.getPositions().stream()
+                .map(ror -> PositionResponseDTO.Detail.from(ror.getOrganizationRole()))
                 .toList();
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/recruitment/recruitment/dto/RecruitmentResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/recruitment/recruitment/dto/RecruitmentResponseDTO.java
@@ -271,12 +271,14 @@ public class RecruitmentResponseDTO {
     @Schema(description = "공고 최소한의 정보 응답 DTO")
     public record Simple(
             @Schema(description = "공고 Id") Long recruitmentId,
-            @Schema(description = "공고 제목") String title
+            @Schema(description = "공고 제목") String title,
+            @Schema(description = "면접 유무") Boolean isInterviewRequired
     ) {
         public static Simple from(Recruitment recruitment) {
             return new Simple(
                     recruitment.getId(),
-                    recruitment.getTitle()
+                    recruitment.getTitle(),
+                    recruitment.isInterviewRequired()
             );
         }
     }

--- a/src/main/java/KUSITMS/WITHUS/domain/template/controller/TemplateController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/template/controller/TemplateController.java
@@ -52,13 +52,24 @@ public class TemplateController {
     }
 
     @PutMapping("/{templateId}")
-    @Operation(summary = "문자/메일 템플릿 수정", description = "기존에 등록된 템플릿의 정보를 수정합니다.")
+    @Operation(summary = "문자/메일 템플릿 수정", description = "기존에 등록된 템플릿의 정보를 수정합니다. 자신이 속한 조직의 템플릿만 수정 가능합니다.")
     public SuccessResponse<TemplateResponseDTO.Detail> update(
             @PathVariable Long templateId,
-            @RequestBody @Valid TemplateRequestDTO.Update dto
+            @RequestBody @Valid TemplateRequestDTO.Update dto,
+            @CurrentUser User user
     ) {
-        TemplateResponseDTO.Detail updated = templateService.update(templateId, dto);
+        TemplateResponseDTO.Detail updated = templateService.update(templateId, dto, user);
         return SuccessResponse.ok(updated);
+    }
+
+    @DeleteMapping("/{templateId}")
+    @Operation(summary = "문자/메일 템플릿 삭제", description = "등록된 템플릿을 삭제합니다. 자신이 속한 조직의 템플릿만 삭제 가능합니다.")
+    public SuccessResponse<String> delete(
+            @PathVariable Long templateId,
+            @CurrentUser User user
+    ) {
+        templateService.delete(templateId, user);
+        return SuccessResponse.ok("템플릿이 삭제되었습니다.");
     }
 
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/template/repository/TemplateRepository.java
@@ -9,4 +9,5 @@ public interface TemplateRepository {
     Template getById(Long templateId);
     List<Template> findAllByMedium(Medium medium, List<Long> organizationIds);
     Template save(Template template);
+    void delete(Long templateId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/template/repository/TemplateRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/template/repository/TemplateRepositoryImpl.java
@@ -22,8 +22,17 @@ public class TemplateRepositoryImpl implements TemplateRepository{
 
     @Override
     public Template getById(Long templateId) {
-        return templateJpaRepository.findById(templateId)
-                .orElseThrow(() -> new CustomException(ErrorCode.TEMPLATE_NOT_FOUND));
+        Template found = queryFactory
+                .selectFrom(template)
+                .join(template.organization, organization).fetchJoin()
+                .where(template.id.eq(templateId))
+                .fetchOne();
+        
+        if (found == null) {
+            throw new CustomException(ErrorCode.TEMPLATE_NOT_FOUND);
+        }
+        
+        return found;
     }
 
     @Override
@@ -40,5 +49,11 @@ public class TemplateRepositoryImpl implements TemplateRepository{
     @Override
     public Template save(Template template) {
         return templateJpaRepository.save(template);
+    }
+
+    @Override
+    public void delete(Long templateId) {
+        Template template = getById(templateId);
+        templateJpaRepository.delete(template);
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/template/service/TemplateService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/template/service/TemplateService.java
@@ -11,5 +11,6 @@ public interface TemplateService {
     TemplateResponseDTO.Detail getById(Long templateId);
     List<TemplateResponseDTO.Summary> listAll(Medium medium, User user);
     TemplateResponseDTO.Detail create(TemplateRequestDTO.Create dto);
-    TemplateResponseDTO.Detail update(Long templateId, TemplateRequestDTO.Update dto);
+    TemplateResponseDTO.Detail update(Long templateId, TemplateRequestDTO.Update dto, User user);
+    void delete(Long templateId, User user);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/template/service/TemplateServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/template/service/TemplateServiceImpl.java
@@ -8,6 +8,8 @@ import KUSITMS.WITHUS.domain.template.entity.Template;
 import KUSITMS.WITHUS.domain.template.enumerate.Medium;
 import KUSITMS.WITHUS.domain.template.repository.TemplateRepository;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.global.exception.CustomException;
+import KUSITMS.WITHUS.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,12 +64,25 @@ public class TemplateServiceImpl implements TemplateService {
         return TemplateResponseDTO.Detail.from(saved);
     }
 
+    /**
+     * 사용자가 속한 조직의 템플릿인지 검증
+     */
+    private void validateUserHasAccess(Template template, User user) {
+        Long templateOrganizationId = template.getOrganization().getId();
+        
+        boolean hasAccess = user.getUserOrganizations().stream()
+                .anyMatch(uo -> uo.getOrganization().getId().equals(templateOrganizationId));
+        
+        if (!hasAccess) {
+            throw new CustomException(ErrorCode.TEMPLATE_NO_PERMISSION);
+        }
+    }
+
     @Override
     @Transactional
-    public TemplateResponseDTO.Detail update(Long templateId, TemplateRequestDTO.Update dto) {
+    public TemplateResponseDTO.Detail update(Long templateId, TemplateRequestDTO.Update dto, User user) {
         Template template = templateRepository.getById(templateId);
-
-        // TODO: 사용자가 속한 조직의 템플릿만 수정하도록 검증 추가 필요
+        validateUserHasAccess(template, user);
 
         template.update(
                 dto.name(),
@@ -77,6 +92,19 @@ public class TemplateServiceImpl implements TemplateService {
         );
 
         return TemplateResponseDTO.Detail.from(template);
+    }
+
+    /**
+     * 문자/메일 템플릿 삭제
+     * @param templateId 삭제할 템플릿 ID
+     * @param user 현재 사용자
+     */
+    @Override
+    @Transactional
+    public void delete(Long templateId, User user) {
+        Template template = templateRepository.getById(templateId);
+        validateUserHasAccess(template, user);
+        templateRepository.delete(templateId);
     }
 
 }

--- a/src/main/java/KUSITMS/WITHUS/global/exception/ErrorCode.java
+++ b/src/main/java/KUSITMS/WITHUS/global/exception/ErrorCode.java
@@ -134,6 +134,7 @@ public enum ErrorCode {
 
     // TEMPLATE
     TEMPLATE_NOT_FOUND("TEMPLATE404", "존재하지 않는 템플릿입니다.", HttpStatus.NOT_FOUND),
+    TEMPLATE_NO_PERMISSION("TEMPLATE403", "해당 템플릿에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
     EMAIL_SUBJECT_REQUIRED("TEMPLATE402", "이메일 템플릿의 경우 제목이 필요합니다.", HttpStatus.BAD_REQUEST),
 
     // EMAIL


### PR DESCRIPTION
### ✨ Related Issue

- #163 

---

### 📌 Task Details
- [x] 해당 공고의 전체 지원자 조회 및 검색
- [x] 문자/메일 템플릿 삭제 api
- [x] api/v1/positions/recruitment/{recruitmentId} 특정 공고의 파트 전체 조회에서 파트 추가한 공고 빈값으로 오는 것 수정 -> 포지션 말고 organizationRole 가져오도록
- [x] /api/v1/admin/applications/distribute-evaluators 지원서 평가 담당자 분배에서 파트가 공통일때도 분배 가능하게 수정
- [x] /api/v1/admin/applications/distribute-evaluators/latest/{recruitmentId} 지원평가 담당자 배정 최신 요청 조회에서 지원파트가 공통일때도 조회 가능하도록 수정
- [x] 면접 유무 값 추가 요청 : /api/v1/recruitments/my-organizations 내가 속한 조직의 모든 리크루팅 목록조회에서 각 공고별 면접 유무를 판단 할 수 있는 값 추가

---

### 💬 Review Requirements (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 모집공고별 지원자 이름/이메일 검색 기능 추가
  * 템플릿 삭제 기능 추가 (사용자 권한 기반)

* **Improvements**
  * 템플릿 수정·삭제 시 사용자 권한 검증 강화
  * 역할 미지정(공통) 대상 지원서 처리 및 평가자 배치 개선
  * 공고 요약에 면접 필요 여부(isInterviewRequired) 노출 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->