### PR TITLE
✨ Feat: (사용자) 홈 - 면접관/안내자로 배정된 전체 타임슬롯 스케줄 조회

### DIFF
--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/controller/InterviewController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/controller/InterviewController.java
@@ -82,11 +82,11 @@ public class InterviewController {
 
     @GetMapping("/me/schedules")
     @Operation(summary = "내 전체 면접자/안내자 배정 결과 조회", description = "로그인한 사용자의 면접자/안내자 배정 결과를 조회합니다. 면접자/안내자로 필터링하여 조회 가능합니다.")
-    public SuccessResponse<InterviewResponseDTO.MyInterviewSchedule> getMyInterviewSchedule(
+    public SuccessResponse<InterviewResponseDTO.Schedule> getMyInterviewSchedule(
             @CurrentUser User user,
             @RequestParam InterviewRole role
     ) {
-        InterviewResponseDTO.MyInterviewSchedule userHome = interviewService.getMyInterviewSchedule(user, role);
+        InterviewResponseDTO.Schedule userHome = interviewService.getMyInterviewSchedule(user, role);
         return SuccessResponse.ok(userHome);
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/controller/InterviewController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/controller/InterviewController.java
@@ -1,5 +1,6 @@
 package KUSITMS.WITHUS.domain.interview.interview.controller;
 
+import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewScheduleDTO;
 import KUSITMS.WITHUS.domain.interview.interview.service.InterviewSchedulerService;
@@ -56,7 +57,7 @@ public class InterviewController {
     }
 
     @GetMapping("/{interviewId}/my-time-slots")
-    @Operation(summary = "내 면접 배정 결과 조회", description = "해당 인터뷰 ID에 배정된 본인의 정보를 조회합니다.")
+    @Operation(summary = "특정 인터뷰의 내 면접 배정 결과 조회", description = "해당 인터뷰 ID에 배정된 본인의 정보를 조회합니다.")
     public SuccessResponse<List<InterviewScheduleDTO>> getSchedule(
             @PathVariable("interviewId") Long interviewId,
             @CurrentUser User user
@@ -77,5 +78,15 @@ public class InterviewController {
     public SuccessResponse<InterviewResponseDTO.Config> getInterviewConfig(@PathVariable Long interviewId) {
         InterviewResponseDTO.Config config = interviewService.getInterviewConfig(interviewId);
         return SuccessResponse.ok(config);
+    }
+
+    @GetMapping("/me/schedules")
+    @Operation(summary = "내 전체 면접자/안내자 배정 결과 조회", description = "로그인한 사용자의 면접자/안내자 배정 결과를 조회합니다. 면접자/안내자로 필터링하여 조회 가능합니다.")
+    public SuccessResponse<InterviewResponseDTO.MyInterviewSchedule> getMyInterviewSchedule(
+            @CurrentUser User user,
+            @RequestParam InterviewRole role
+    ) {
+        InterviewResponseDTO.MyInterviewSchedule userHome = interviewService.getMyInterviewSchedule(user, role);
+        return SuccessResponse.ok(userHome);
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/dto/InterviewResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/dto/InterviewResponseDTO.java
@@ -1,8 +1,11 @@
 package KUSITMS.WITHUS.domain.interview.interview.dto;
 
+import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
 import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Schema(description = "면접 관련 응답 DTO")
@@ -24,4 +27,37 @@ public class InterviewResponseDTO {
             );
         }
     }
+
+    public record MyInterviewSchedule(
+            InterviewRole role,
+            List<DateGroup> dates
+    ) {
+        public record DateGroup(
+                LocalDate date,
+                List<SlotCard> timeSlots
+        ) {}
+
+        public record SlotCard(
+                Long timeSlotId,
+                Long interviewId,
+                String roomName,
+                LocalTime startTime,
+                LocalTime endTime,
+                List<ApplicantSimple> applicants,
+                List<UserSimple> interviewers,
+                List<UserSimple> assistants
+        ) {}
+
+        public record ApplicantSimple(
+                Long applicationId,
+                String name
+        ) {}
+
+        public record UserSimple(
+                Long userId,
+                String name,
+                String profileImageUrl
+        ) {}
+    }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/dto/InterviewResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/dto/InterviewResponseDTO.java
@@ -2,10 +2,11 @@ package KUSITMS.WITHUS.domain.interview.interview.dto;
 
 import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
 import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
+import KUSITMS.WITHUS.domain.interview.timeslot.dto.TimeSlotResponseDTO;
+import KUSITMS.WITHUS.global.common.annotation.DateFormatSlash;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 @Schema(description = "면접 관련 응답 DTO")
@@ -28,36 +29,22 @@ public class InterviewResponseDTO {
         }
     }
 
-    public record MyInterviewSchedule(
-            InterviewRole role,
-            List<DateGroup> dates
+    public record Schedule(
+            @Schema(description = "면접관/안내자 역할") InterviewRole role,
+            @Schema(description = "날짜") List<DateGroup> dates
     ) {
+        public static Schedule from(InterviewRole role, List<DateGroup> dates) {
+            return new InterviewResponseDTO.Schedule(role, dates);
+        }
+
         public record DateGroup(
-                LocalDate date,
-                List<SlotCard> timeSlots
-        ) {}
-
-        public record SlotCard(
-                Long timeSlotId,
-                Long interviewId,
-                String roomName,
-                LocalTime startTime,
-                LocalTime endTime,
-                List<ApplicantSimple> applicants,
-                List<UserSimple> interviewers,
-                List<UserSimple> assistants
-        ) {}
-
-        public record ApplicantSimple(
-                Long applicationId,
-                String name
-        ) {}
-
-        public record UserSimple(
-                Long userId,
-                String name,
-                String profileImageUrl
-        ) {}
+                @DateFormatSlash LocalDate date,
+                List<TimeSlotResponseDTO.ScheduleCard> timeSlots
+        ) {
+            public static DateGroup from(LocalDate date, List<TimeSlotResponseDTO.ScheduleCard> timeSlots) {
+                return new DateGroup(date, timeSlots);
+            }
+        }
     }
 
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewService.java
@@ -13,5 +13,5 @@ public interface InterviewService {
     Interview getById(Long interviewId);
     InterviewResponseDTO.Config getInterviewConfig(Long interviewId);
     List<InterviewScheduleDTO.InterviewScheduleSummaryDTO> getOrganizationInterviews(Long organizationId);
-    InterviewResponseDTO.MyInterviewSchedule getMyInterviewSchedule(User user, InterviewRole role);
+    InterviewResponseDTO.Schedule getMyInterviewSchedule(User user, InterviewRole role);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewService.java
@@ -1,8 +1,10 @@
 package KUSITMS.WITHUS.domain.interview.interview.service;
 
+import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewScheduleDTO;
 import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
 
 import java.util.List;
 
@@ -11,4 +13,5 @@ public interface InterviewService {
     Interview getById(Long interviewId);
     InterviewResponseDTO.Config getInterviewConfig(Long interviewId);
     List<InterviewScheduleDTO.InterviewScheduleSummaryDTO> getOrganizationInterviews(Long organizationId);
+    InterviewResponseDTO.MyInterviewSchedule getMyInterviewSchedule(User user, InterviewRole role);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewServiceImpl.java
@@ -2,20 +2,25 @@ package KUSITMS.WITHUS.domain.interview.interview.service;
 
 import KUSITMS.WITHUS.domain.application.application.entity.Application;
 import KUSITMS.WITHUS.domain.application.application.repository.ApplicationRepository;
+import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewScheduleDTO;
 import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
 import KUSITMS.WITHUS.domain.interview.interview.repository.InterviewRepository;
+import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
+import KUSITMS.WITHUS.domain.interview.timeslot.repository.TimeSlotRepository;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.repository.TimeSlotUserRepository;
 import KUSITMS.WITHUS.domain.recruitment.availableTimeRange.dto.AvailableTimeRangeResponseDTO;
 import KUSITMS.WITHUS.domain.recruitment.recruitment.entity.Recruitment;
 import KUSITMS.WITHUS.domain.recruitment.recruitment.repository.RecruitmentRepository;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.time.LocalDate;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -27,6 +32,8 @@ public class InterviewServiceImpl implements InterviewService {
     private final InterviewRepository interviewRepository;
     private final ApplicationRepository applicationRepository;
     private final RecruitmentRepository recruitmentRepository;
+    private final TimeSlotRepository timeSlotRepository;
+    private final TimeSlotUserRepository timeSlotUserRepository;
 
     @Override
     @Transactional
@@ -91,6 +98,95 @@ public class InterviewServiceImpl implements InterviewService {
                     );
                 })
                 .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public InterviewResponseDTO.MyInterviewSchedule getMyInterviewSchedule(User user, InterviewRole role) {
+
+        List<Long> timeSlotIds = timeSlotUserRepository.findMyTimeSlotIds(user.getId(), role);
+        if (timeSlotIds.isEmpty()) {
+            return new InterviewResponseDTO.MyInterviewSchedule(role, List.of());
+        }
+
+        // 1) 슬롯 + (interview/recruitment) + applications 로딩
+        List<TimeSlot> slots = timeSlotRepository.findAllByIdIn(timeSlotIds);
+
+        // 2) 슬롯에 연결된 TimeSlotUser(+User) 로딩
+        List<TimeSlotUser> tsUsers = timeSlotUserRepository.findAllByTimeSlotIdInWithUser(timeSlotIds);
+
+        Map<Long, List<TimeSlotUser>> tsUsersBySlotId = tsUsers.stream()
+                .collect(Collectors.groupingBy(tsu -> tsu.getTimeSlot().getId()));
+
+        // 3) DTO로 변환
+        List<InterviewResponseDTO.MyInterviewSchedule.SlotCard> cards = slots.stream()
+                .map(slot -> {
+                    List<InterviewResponseDTO.MyInterviewSchedule.ApplicantSimple> applicants =
+                            slot.getApplications().stream()
+                                    .map(app -> new InterviewResponseDTO.MyInterviewSchedule.ApplicantSimple(app.getId(), app.getName()))
+                                    .toList();
+
+                    List<TimeSlotUser> usersInSlot = tsUsersBySlotId.getOrDefault(slot.getId(), List.of());
+
+                    List<InterviewResponseDTO.MyInterviewSchedule.UserSimple> interviewers =
+                            usersInSlot.stream()
+                                    .filter(u -> u.getRole() == InterviewRole.INTERVIEWER)
+                                    .map(u -> new InterviewResponseDTO.MyInterviewSchedule.UserSimple(
+                                            u.getUser().getId(),
+                                            u.getUser().getName(),
+                                            u.getUser().getProfileImageUrl()
+                                    ))
+                                    .toList();
+
+                    List<InterviewResponseDTO.MyInterviewSchedule.UserSimple> assistants =
+                            usersInSlot.stream()
+                                    .filter(u -> u.getRole() == InterviewRole.ASSISTANT)
+                                    .map(u -> new InterviewResponseDTO.MyInterviewSchedule.UserSimple(
+                                            u.getUser().getId(),
+                                            u.getUser().getName(),
+                                            u.getUser().getProfileImageUrl()
+                                    ))
+                                    .toList();
+
+                    return new InterviewResponseDTO.MyInterviewSchedule.SlotCard(
+                            slot.getId(),
+                            slot.getInterview().getId(),
+                            slot.getRoomName(),
+                            slot.getStartTime(),
+                            slot.getEndTime(),
+                            applicants,
+                            interviewers,
+                            assistants
+                    );
+                })
+                // 시간순 정렬(같은 날짜 안에서)
+                .sorted(Comparator
+                        .comparing(InterviewResponseDTO.MyInterviewSchedule.SlotCard::startTime)
+                        .thenComparing(InterviewResponseDTO.MyInterviewSchedule.SlotCard::timeSlotId))
+                .toList();
+
+        // 4) 날짜별 그룹핑
+        Map<LocalDate, List<InterviewResponseDTO.MyInterviewSchedule.SlotCard>> byDate = new LinkedHashMap<>();
+        for (TimeSlot slot : slots.stream()
+                .sorted(Comparator.comparing(TimeSlot::getDate).thenComparing(TimeSlot::getStartTime))
+                .toList()) {
+            byDate.putIfAbsent(slot.getDate(), new ArrayList<>());
+        }
+
+        // cards는 slotId 기반이라 date 매핑이 필요함
+        Map<Long, LocalDate> slotDateMap = slots.stream()
+                .collect(Collectors.toMap(TimeSlot::getId, TimeSlot::getDate));
+
+        for (InterviewResponseDTO.MyInterviewSchedule.SlotCard card : cards) {
+            LocalDate d = slotDateMap.get(card.timeSlotId());
+            byDate.computeIfAbsent(d, k -> new ArrayList<>()).add(card);
+        }
+
+        List<InterviewResponseDTO.MyInterviewSchedule.DateGroup> dateGroups = byDate.entrySet().stream()
+                .map(e -> new InterviewResponseDTO.MyInterviewSchedule.DateGroup(e.getKey(), e.getValue()))
+                .toList();
+
+        return new InterviewResponseDTO.MyInterviewSchedule(role, dateGroups);
     }
 
     @Override

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewServiceImpl.java
@@ -1,5 +1,6 @@
 package KUSITMS.WITHUS.domain.interview.interview.service;
 
+import KUSITMS.WITHUS.domain.application.application.dto.ApplicationResponseDTO;
 import KUSITMS.WITHUS.domain.application.application.entity.Application;
 import KUSITMS.WITHUS.domain.application.application.repository.ApplicationRepository;
 import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
@@ -7,6 +8,7 @@ import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewScheduleDTO;
 import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
 import KUSITMS.WITHUS.domain.interview.interview.repository.InterviewRepository;
+import KUSITMS.WITHUS.domain.interview.timeslot.dto.TimeSlotResponseDTO;
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
 import KUSITMS.WITHUS.domain.interview.timeslot.repository.TimeSlotRepository;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
@@ -14,6 +16,7 @@ import KUSITMS.WITHUS.domain.interview.timeslotUser.repository.TimeSlotUserRepos
 import KUSITMS.WITHUS.domain.recruitment.availableTimeRange.dto.AvailableTimeRangeResponseDTO;
 import KUSITMS.WITHUS.domain.recruitment.recruitment.entity.Recruitment;
 import KUSITMS.WITHUS.domain.recruitment.recruitment.repository.RecruitmentRepository;
+import KUSITMS.WITHUS.domain.user.user.dto.UserResponseDTO;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -102,71 +105,54 @@ public class InterviewServiceImpl implements InterviewService {
 
     @Override
     @Transactional(readOnly = true)
-    public InterviewResponseDTO.MyInterviewSchedule getMyInterviewSchedule(User user, InterviewRole role) {
+    public InterviewResponseDTO.Schedule getMyInterviewSchedule(User user, InterviewRole role) {
 
         List<Long> timeSlotIds = timeSlotUserRepository.findMyTimeSlotIds(user.getId(), role);
         if (timeSlotIds.isEmpty()) {
-            return new InterviewResponseDTO.MyInterviewSchedule(role, List.of());
+            return InterviewResponseDTO.Schedule.from(role, List.of());
         }
 
-        // 1) 슬롯 + (interview/recruitment) + applications 로딩
+        // 타임슬롯 + (interview/recruitment) + applications 로딩
         List<TimeSlot> slots = timeSlotRepository.findAllByIdIn(timeSlotIds);
 
-        // 2) 슬롯에 연결된 TimeSlotUser(+User) 로딩
+        // 타임슬롯에 연결된 TimeSlotUser(+User) 로딩
         List<TimeSlotUser> tsUsers = timeSlotUserRepository.findAllByTimeSlotIdInWithUser(timeSlotIds);
 
         Map<Long, List<TimeSlotUser>> tsUsersBySlotId = tsUsers.stream()
                 .collect(Collectors.groupingBy(tsu -> tsu.getTimeSlot().getId()));
 
-        // 3) DTO로 변환
-        List<InterviewResponseDTO.MyInterviewSchedule.SlotCard> cards = slots.stream()
+        // DTO로 변환
+        List<TimeSlotResponseDTO.ScheduleCard> cards = slots.stream()
                 .map(slot -> {
-                    List<InterviewResponseDTO.MyInterviewSchedule.ApplicantSimple> applicants =
+                    List<ApplicationResponseDTO.Applicant> applicants =
                             slot.getApplications().stream()
-                                    .map(app -> new InterviewResponseDTO.MyInterviewSchedule.ApplicantSimple(app.getId(), app.getName()))
+                                    .map(ApplicationResponseDTO.Applicant::from)
                                     .toList();
 
                     List<TimeSlotUser> usersInSlot = tsUsersBySlotId.getOrDefault(slot.getId(), List.of());
 
-                    List<InterviewResponseDTO.MyInterviewSchedule.UserSimple> interviewers =
+                    List<UserResponseDTO.Summary> interviewers =
                             usersInSlot.stream()
                                     .filter(u -> u.getRole() == InterviewRole.INTERVIEWER)
-                                    .map(u -> new InterviewResponseDTO.MyInterviewSchedule.UserSimple(
-                                            u.getUser().getId(),
-                                            u.getUser().getName(),
-                                            u.getUser().getProfileImageUrl()
-                                    ))
+                                    .map(u -> UserResponseDTO.Summary.from(u.getUser()))
                                     .toList();
 
-                    List<InterviewResponseDTO.MyInterviewSchedule.UserSimple> assistants =
+                    List<UserResponseDTO.Summary> assistants =
                             usersInSlot.stream()
                                     .filter(u -> u.getRole() == InterviewRole.ASSISTANT)
-                                    .map(u -> new InterviewResponseDTO.MyInterviewSchedule.UserSimple(
-                                            u.getUser().getId(),
-                                            u.getUser().getName(),
-                                            u.getUser().getProfileImageUrl()
-                                    ))
+                                    .map(u -> UserResponseDTO.Summary.from(u.getUser()))
                                     .toList();
 
-                    return new InterviewResponseDTO.MyInterviewSchedule.SlotCard(
-                            slot.getId(),
-                            slot.getInterview().getId(),
-                            slot.getRoomName(),
-                            slot.getStartTime(),
-                            slot.getEndTime(),
-                            applicants,
-                            interviewers,
-                            assistants
-                    );
+                    return TimeSlotResponseDTO.ScheduleCard.from(slot, applicants, interviewers, assistants);
                 })
                 // 시간순 정렬(같은 날짜 안에서)
                 .sorted(Comparator
-                        .comparing(InterviewResponseDTO.MyInterviewSchedule.SlotCard::startTime)
-                        .thenComparing(InterviewResponseDTO.MyInterviewSchedule.SlotCard::timeSlotId))
+                        .comparing(TimeSlotResponseDTO.ScheduleCard::startTime)
+                        .thenComparing(TimeSlotResponseDTO.ScheduleCard::timeSlotId))
                 .toList();
 
-        // 4) 날짜별 그룹핑
-        Map<LocalDate, List<InterviewResponseDTO.MyInterviewSchedule.SlotCard>> byDate = new LinkedHashMap<>();
+        // 날짜별 그룹핑
+        Map<LocalDate, List<TimeSlotResponseDTO.ScheduleCard>> byDate = new LinkedHashMap<>();
         for (TimeSlot slot : slots.stream()
                 .sorted(Comparator.comparing(TimeSlot::getDate).thenComparing(TimeSlot::getStartTime))
                 .toList()) {
@@ -177,16 +163,16 @@ public class InterviewServiceImpl implements InterviewService {
         Map<Long, LocalDate> slotDateMap = slots.stream()
                 .collect(Collectors.toMap(TimeSlot::getId, TimeSlot::getDate));
 
-        for (InterviewResponseDTO.MyInterviewSchedule.SlotCard card : cards) {
+        for (TimeSlotResponseDTO.ScheduleCard card : cards) {
             LocalDate d = slotDateMap.get(card.timeSlotId());
             byDate.computeIfAbsent(d, k -> new ArrayList<>()).add(card);
         }
 
-        List<InterviewResponseDTO.MyInterviewSchedule.DateGroup> dateGroups = byDate.entrySet().stream()
-                .map(e -> new InterviewResponseDTO.MyInterviewSchedule.DateGroup(e.getKey(), e.getValue()))
+        List<InterviewResponseDTO.Schedule.DateGroup> dateGroups = byDate.entrySet().stream()
+                .map(e -> InterviewResponseDTO.Schedule.DateGroup.from(e.getKey(), e.getValue()))
                 .toList();
 
-        return new InterviewResponseDTO.MyInterviewSchedule(role, dateGroups);
+        return new InterviewResponseDTO.Schedule(role, dateGroups);
     }
 
     @Override

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/InterviewServiceImpl.java
@@ -8,6 +8,7 @@ import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
 import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewScheduleDTO;
 import KUSITMS.WITHUS.domain.interview.interview.entity.Interview;
 import KUSITMS.WITHUS.domain.interview.interview.repository.InterviewRepository;
+import KUSITMS.WITHUS.domain.interview.interview.service.assembler.InterviewScheduleAssembler;
 import KUSITMS.WITHUS.domain.interview.timeslot.dto.TimeSlotResponseDTO;
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
 import KUSITMS.WITHUS.domain.interview.timeslot.repository.TimeSlotRepository;
@@ -37,6 +38,7 @@ public class InterviewServiceImpl implements InterviewService {
     private final RecruitmentRepository recruitmentRepository;
     private final TimeSlotRepository timeSlotRepository;
     private final TimeSlotUserRepository timeSlotUserRepository;
+    private final InterviewScheduleAssembler scheduleAssembler;
 
     @Override
     @Transactional
@@ -106,71 +108,19 @@ public class InterviewServiceImpl implements InterviewService {
     @Override
     @Transactional(readOnly = true)
     public InterviewResponseDTO.Schedule getMyInterviewSchedule(User user, InterviewRole role) {
-
         List<Long> timeSlotIds = timeSlotUserRepository.findMyTimeSlotIds(user.getId(), role);
         if (timeSlotIds.isEmpty()) {
             return InterviewResponseDTO.Schedule.from(role, List.of());
         }
 
-        // 타임슬롯 + (interview/recruitment) + applications 로딩
         List<TimeSlot> slots = timeSlotRepository.findAllByIdIn(timeSlotIds);
+        Map<Long, List<TimeSlotUser>> tsUsersBySlotId = scheduleAssembler.loadTimeSlotUsersGrouped(timeSlotIds);
 
-        // 타임슬롯에 연결된 TimeSlotUser(+User) 로딩
-        List<TimeSlotUser> tsUsers = timeSlotUserRepository.findAllByTimeSlotIdInWithUser(timeSlotIds);
+        List<TimeSlotResponseDTO.ScheduleCard> cards =
+                scheduleAssembler.buildScheduleCards(slots, tsUsersBySlotId);
 
-        Map<Long, List<TimeSlotUser>> tsUsersBySlotId = tsUsers.stream()
-                .collect(Collectors.groupingBy(tsu -> tsu.getTimeSlot().getId()));
-
-        // DTO로 변환
-        List<TimeSlotResponseDTO.ScheduleCard> cards = slots.stream()
-                .map(slot -> {
-                    List<ApplicationResponseDTO.Applicant> applicants =
-                            slot.getApplications().stream()
-                                    .map(ApplicationResponseDTO.Applicant::from)
-                                    .toList();
-
-                    List<TimeSlotUser> usersInSlot = tsUsersBySlotId.getOrDefault(slot.getId(), List.of());
-
-                    List<UserResponseDTO.Summary> interviewers =
-                            usersInSlot.stream()
-                                    .filter(u -> u.getRole() == InterviewRole.INTERVIEWER)
-                                    .map(u -> UserResponseDTO.Summary.from(u.getUser()))
-                                    .toList();
-
-                    List<UserResponseDTO.Summary> assistants =
-                            usersInSlot.stream()
-                                    .filter(u -> u.getRole() == InterviewRole.ASSISTANT)
-                                    .map(u -> UserResponseDTO.Summary.from(u.getUser()))
-                                    .toList();
-
-                    return TimeSlotResponseDTO.ScheduleCard.from(slot, applicants, interviewers, assistants);
-                })
-                // 시간순 정렬(같은 날짜 안에서)
-                .sorted(Comparator
-                        .comparing(TimeSlotResponseDTO.ScheduleCard::startTime)
-                        .thenComparing(TimeSlotResponseDTO.ScheduleCard::timeSlotId))
-                .toList();
-
-        // 날짜별 그룹핑
-        Map<LocalDate, List<TimeSlotResponseDTO.ScheduleCard>> byDate = new LinkedHashMap<>();
-        for (TimeSlot slot : slots.stream()
-                .sorted(Comparator.comparing(TimeSlot::getDate).thenComparing(TimeSlot::getStartTime))
-                .toList()) {
-            byDate.putIfAbsent(slot.getDate(), new ArrayList<>());
-        }
-
-        // cards는 slotId 기반이라 date 매핑이 필요함
-        Map<Long, LocalDate> slotDateMap = slots.stream()
-                .collect(Collectors.toMap(TimeSlot::getId, TimeSlot::getDate));
-
-        for (TimeSlotResponseDTO.ScheduleCard card : cards) {
-            LocalDate d = slotDateMap.get(card.timeSlotId());
-            byDate.computeIfAbsent(d, k -> new ArrayList<>()).add(card);
-        }
-
-        List<InterviewResponseDTO.Schedule.DateGroup> dateGroups = byDate.entrySet().stream()
-                .map(e -> InterviewResponseDTO.Schedule.DateGroup.from(e.getKey(), e.getValue()))
-                .toList();
+        List<InterviewResponseDTO.Schedule.DateGroup> dateGroups =
+                scheduleAssembler.groupCardsByDate(slots, cards);
 
         return new InterviewResponseDTO.Schedule(role, dateGroups);
     }
@@ -186,4 +136,5 @@ public class InterviewServiceImpl implements InterviewService {
                 interview.getAssistantPerSlot()
         );
     }
+
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/assembler/InterviewScheduleAssembler.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/interview/service/assembler/InterviewScheduleAssembler.java
@@ -1,0 +1,89 @@
+package KUSITMS.WITHUS.domain.interview.interview.service.assembler;
+
+import KUSITMS.WITHUS.domain.application.application.dto.ApplicationResponseDTO;
+import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
+import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
+import KUSITMS.WITHUS.domain.interview.timeslot.dto.TimeSlotResponseDTO;
+import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
+import KUSITMS.WITHUS.domain.interview.timeslotUser.repository.TimeSlotUserRepository;
+import KUSITMS.WITHUS.domain.user.user.dto.UserResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class InterviewScheduleAssembler {
+
+    private final TimeSlotUserRepository timeSlotUserRepository;
+
+    public Map<Long, List<TimeSlotUser>> loadTimeSlotUsersGrouped(List<Long> timeSlotIds) {
+        return timeSlotUserRepository.findAllByTimeSlotIdInWithUser(timeSlotIds)
+                .stream()
+                .collect(Collectors.groupingBy(tsu -> tsu.getTimeSlot().getId()));
+    }
+
+    public List<TimeSlotResponseDTO.ScheduleCard> buildScheduleCards(
+            List<TimeSlot> slots,
+            Map<Long, List<TimeSlotUser>> tsUsersBySlotId
+    ) {
+        return slots.stream()
+                .map(slot -> toScheduleCard(slot, tsUsersBySlotId))
+                .sorted(Comparator
+                        .comparing(TimeSlotResponseDTO.ScheduleCard::startTime)
+                        .thenComparing(TimeSlotResponseDTO.ScheduleCard::timeSlotId))
+                .toList();
+    }
+
+    public List<InterviewResponseDTO.Schedule.DateGroup> groupCardsByDate(
+            List<TimeSlot> slots,
+            List<TimeSlotResponseDTO.ScheduleCard> cards
+    ) {
+        Map<Long, LocalDate> slotDateMap = slots.stream()
+                .collect(Collectors.toMap(TimeSlot::getId, TimeSlot::getDate));
+
+        Map<LocalDate, List<TimeSlotResponseDTO.ScheduleCard>> byDate = new LinkedHashMap<>();
+
+        slots.stream()
+                .sorted(Comparator.comparing(TimeSlot::getDate)
+                        .thenComparing(TimeSlot::getStartTime))
+                .forEach(slot -> byDate.putIfAbsent(slot.getDate(), new ArrayList<>()));
+
+        for (TimeSlotResponseDTO.ScheduleCard card : cards) {
+            LocalDate date = slotDateMap.get(card.timeSlotId());
+            byDate.get(date).add(card);
+        }
+
+        return byDate.entrySet().stream()
+                .map(e -> InterviewResponseDTO.Schedule.DateGroup.from(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    private TimeSlotResponseDTO.ScheduleCard toScheduleCard(
+            TimeSlot slot,
+            Map<Long, List<TimeSlotUser>> tsUsersBySlotId
+    ) {
+        List<ApplicationResponseDTO.Applicant> applicants =
+                slot.getApplications().stream()
+                        .map(ApplicationResponseDTO.Applicant::from)
+                        .toList();
+
+        List<TimeSlotUser> usersInSlot = tsUsersBySlotId.getOrDefault(slot.getId(), List.of());
+
+        List<UserResponseDTO.Summary> interviewers = filterUsersByRole(usersInSlot, InterviewRole.INTERVIEWER);
+        List<UserResponseDTO.Summary> assistants = filterUsersByRole(usersInSlot, InterviewRole.ASSISTANT);
+
+        return TimeSlotResponseDTO.ScheduleCard.from(slot, applicants, interviewers, assistants);
+    }
+
+    private List<UserResponseDTO.Summary> filterUsersByRole(List<TimeSlotUser> users, InterviewRole role) {
+        return users.stream()
+                .filter(u -> u.getRole() == role)
+                .map(u -> UserResponseDTO.Summary.from(u.getUser()))
+                .toList();
+    }
+}

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/controller/TimeSlotController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/controller/TimeSlotController.java
@@ -30,7 +30,7 @@ public class TimeSlotController {
 
     @GetMapping("/{timeSlotId}")
     @Operation(summary = "타임슬롯 조회", description = "특정 타임슬롯에 배정된 사용자/지원자 목록을 조회합니다.")
-    public SuccessResponse<TimeSlotResponseDTO> getUsersByTimeSlot(
+    public SuccessResponse<TimeSlotResponseDTO.Detail> getUsersByTimeSlot(
             @PathVariable Long timeSlotId
     ) {
         return SuccessResponse.ok(timeSlotService.getTimeSlotDetail(timeSlotId));

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/TimeSlotResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/TimeSlotResponseDTO.java
@@ -53,7 +53,7 @@ public class TimeSlotResponseDTO {
         public static TimeSlotResponseDTO.ScheduleCard from(TimeSlot slot, List<ApplicationResponseDTO.Applicant> applicants, List<UserResponseDTO.Summary> interviewers, List<UserResponseDTO.Summary> assistants) {
             return new TimeSlotResponseDTO.ScheduleCard(
                     slot.getId(),
-                    slot.getInterview().getId(),
+                    slot.getInterview() != null ? slot.getInterview().getId() : null,
                     slot.getRoomName(),
                     slot.getStartTime(),
                     slot.getEndTime(),

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/TimeSlotResponseDTO.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/dto/TimeSlotResponseDTO.java
@@ -1,10 +1,12 @@
 package KUSITMS.WITHUS.domain.interview.timeslot.dto;
 
 import KUSITMS.WITHUS.domain.application.application.dto.ApplicationResponseDTO;
+import KUSITMS.WITHUS.domain.interview.interview.dto.InterviewResponseDTO;
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.dto.TimeSlotUserResponseDTO;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
 import KUSITMS.WITHUS.domain.organization.organizationRole.dto.OrganizationRoleResponseDTO;
+import KUSITMS.WITHUS.domain.user.user.dto.UserResponseDTO;
 import KUSITMS.WITHUS.global.common.annotation.TimeFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -12,27 +14,53 @@ import java.time.LocalTime;
 import java.util.List;
 
 @Schema(description = "타임슬롯 응답 DTO")
-public record TimeSlotResponseDTO(
-        @Schema(description = "타임슬롯 ID") Long timeSlotId,
-        @Schema(description = "시작 시각") @TimeFormat LocalTime startAt,
-        @Schema(description = "종료 시각") @TimeFormat LocalTime endAt,
-        @Schema(description = "역할") OrganizationRoleResponseDTO.Detail organizationRole,
+public class TimeSlotResponseDTO {
+    public record Detail(
+            @Schema(description = "타임슬롯 ID") Long timeSlotId,
+            @Schema(description = "시작 시각") @TimeFormat LocalTime startAt,
+            @Schema(description = "종료 시각") @TimeFormat LocalTime endAt,
+            @Schema(description = "역할") OrganizationRoleResponseDTO.Detail organizationRole,
 
-        @Schema(description = "배정된 사용자 목록") List<TimeSlotUserResponseDTO> users,
-        @Schema(description = "배정된 지원자 목록") List<ApplicationResponseDTO.Applicant> applicants
-) {
-    public static TimeSlotResponseDTO from(
-            TimeSlot slot,
-            List<TimeSlotUser> users,
-            List<ApplicationResponseDTO.Applicant> applicants
+            @Schema(description = "배정된 사용자 목록") List<TimeSlotUserResponseDTO> users,
+            @Schema(description = "배정된 지원자 목록") List<ApplicationResponseDTO.Applicant> applicants
     ) {
-        return new TimeSlotResponseDTO(
-                slot.getId(),
-                slot.getStartTime(),
-                slot.getEndTime(),
-                slot.getOrganizationRole() != null ? OrganizationRoleResponseDTO.Detail.from(slot.getOrganizationRole()) : null,
-                users.stream().map(TimeSlotUserResponseDTO::from).toList(),
-                applicants
-        );
+        public static TimeSlotResponseDTO.Detail from(
+                TimeSlot slot,
+                List<TimeSlotUser> users,
+                List<ApplicationResponseDTO.Applicant> applicants
+        ) {
+            return new TimeSlotResponseDTO.Detail(
+                    slot.getId(),
+                    slot.getStartTime(),
+                    slot.getEndTime(),
+                    slot.getOrganizationRole() != null ? OrganizationRoleResponseDTO.Detail.from(slot.getOrganizationRole()) : null,
+                    users.stream().map(TimeSlotUserResponseDTO::from).toList(),
+                    applicants
+            );
+        }
+    }
+
+    public record ScheduleCard(
+            Long timeSlotId,
+            Long interviewId,
+            String roomName,
+            @TimeFormat LocalTime startTime,
+            @TimeFormat LocalTime endTime,
+            List<ApplicationResponseDTO.Applicant> applicants,
+            List<UserResponseDTO.Summary> interviewers,
+            List<UserResponseDTO.Summary> assistants
+    ) {
+        public static TimeSlotResponseDTO.ScheduleCard from(TimeSlot slot, List<ApplicationResponseDTO.Applicant> applicants, List<UserResponseDTO.Summary> interviewers, List<UserResponseDTO.Summary> assistants) {
+            return new TimeSlotResponseDTO.ScheduleCard(
+                    slot.getId(),
+                    slot.getInterview().getId(),
+                    slot.getRoomName(),
+                    slot.getStartTime(),
+                    slot.getEndTime(),
+                    applicants,
+                    interviewers,
+                    assistants
+            );
+        }
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotJpaRepository.java
@@ -1,8 +1,18 @@
 package KUSITMS.WITHUS.domain.interview.timeslot.repository;
 
 import KUSITMS.WITHUS.domain.interview.timeslot.entity.TimeSlot;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface TimeSlotJpaRepository extends JpaRepository<TimeSlot, Long> {
     void deleteByInterviewId(Long interviewId);
+
+    @EntityGraph(attributePaths = {
+            "interview",
+            "interview.recruitment",
+            "applications"
+    })
+    List<TimeSlot> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepository.java
@@ -19,4 +19,5 @@ public interface TimeSlotRepository {
     List<TimeSlot> findAllByUserInvolved(Long interviewId, User user);
     void deleteAllByInterview(Long interviewId);
     void deleteAll(List<TimeSlot> oldSlots);
+    List<TimeSlot> findAllByIdIn(List<Long> timeSlotIds);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/repository/TimeSlotRepositoryImpl.java
@@ -103,4 +103,9 @@ public class TimeSlotRepositoryImpl implements TimeSlotRepository {
     public void deleteAll(List<TimeSlot> oldSlots) {
         timeSlotJpaRepository.deleteAll(oldSlots);
     }
+
+    @Override
+    public List<TimeSlot> findAllByIdIn(List<Long> timeSlotIds) {
+        return timeSlotJpaRepository.findAllByIdIn(timeSlotIds);
+    }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotService.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotService.java
@@ -9,5 +9,5 @@ public interface TimeSlotService {
     List<ApplicationResponseDTO.DetailForTimeSlot> getApplicationsByTimeSlotFilteredByUser(Long timeSlotId, Long currentUserId);
     void addApplicantToTimeSlot(Long timeSlotId, List<Long> applicantIds);
     void updateApplicantInTimeSlot(Long timeSlotId, List<Long> applicantIds);
-    TimeSlotResponseDTO getTimeSlotDetail(Long timeSlotId);
+    TimeSlotResponseDTO.Detail getTimeSlotDetail(Long timeSlotId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslot/service/TimeSlotServiceImpl.java
@@ -108,7 +108,7 @@ public class TimeSlotServiceImpl implements TimeSlotService {
     }
 
     @Override
-    public TimeSlotResponseDTO getTimeSlotDetail(Long timeSlotId) {
+    public TimeSlotResponseDTO.Detail getTimeSlotDetail(Long timeSlotId) {
         TimeSlot slot = timeSlotRepository.getById(timeSlotId);
 
         List<TimeSlotUser> users = timeSlotUserRepository.findByTimeSlotId(timeSlotId);
@@ -118,6 +118,6 @@ public class TimeSlotServiceImpl implements TimeSlotService {
                         .map(ApplicationResponseDTO.Applicant::from)
                         .toList();
 
-        return TimeSlotResponseDTO.from(slot, users, applicants);
+        return TimeSlotResponseDTO.Detail.from(slot, users, applicants);
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserJpaRepository.java
@@ -1,29 +1,10 @@
 package KUSITMS.WITHUS.domain.interview.timeslotUser.repository;
 
-import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface TimeSlotUserJpaRepository extends JpaRepository<TimeSlotUser, Long> {
     List<TimeSlotUser> findByTimeSlotId(Long timeSlotId);
-
-    @Query("""
-        select tsu
-        from TimeSlotUser tsu
-        join fetch tsu.user u
-        join fetch tsu.timeSlot ts
-        where tsu.timeSlot.id in :timeSlotIds
-    """)
-    List<TimeSlotUser> findAllByTimeSlotIdInWithUser(List<Long> timeSlotIds);
-
-    @Query("""
-        select distinct tsu.timeSlot.id
-        from TimeSlotUser tsu
-        where tsu.user.id = :userId
-          and tsu.role = :role
-    """)
-    List<Long> findMyTimeSlotIds(Long userId, InterviewRole role);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserJpaRepository.java
@@ -1,10 +1,29 @@
 package KUSITMS.WITHUS.domain.interview.timeslotUser.repository;
 
+import KUSITMS.WITHUS.domain.interview.enumerate.InterviewRole;
 import KUSITMS.WITHUS.domain.interview.timeslotUser.entity.TimeSlotUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface TimeSlotUserJpaRepository extends JpaRepository<TimeSlotUser, Long> {
     List<TimeSlotUser> findByTimeSlotId(Long timeSlotId);
+
+    @Query("""
+        select tsu
+        from TimeSlotUser tsu
+        join fetch tsu.user u
+        join fetch tsu.timeSlot ts
+        where tsu.timeSlot.id in :timeSlotIds
+    """)
+    List<TimeSlotUser> findAllByTimeSlotIdInWithUser(List<Long> timeSlotIds);
+
+    @Query("""
+        select distinct tsu.timeSlot.id
+        from TimeSlotUser tsu
+        where tsu.user.id = :userId
+          and tsu.role = :role
+    """)
+    List<Long> findMyTimeSlotIds(Long userId, InterviewRole role);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserRepository.java
@@ -9,4 +9,6 @@ public interface TimeSlotUserRepository {
     void save(TimeSlotUser timeSlotUser);
     List<TimeSlotUser> findByTimeSlotId(Long timeSlotId);
     void deleteByInterviewIdAndRole(Long interviewId, InterviewRole role);
+    List<Long> findMyTimeSlotIds(Long id, InterviewRole role);
+    List<TimeSlotUser> findAllByTimeSlotIdInWithUser(List<Long> timeSlotIds);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserRepositoryImpl.java
@@ -38,12 +38,27 @@ public class TimeSlotUserRepositoryImpl implements TimeSlotUserRepository {
     }
 
     @Override
-    public List<Long> findMyTimeSlotIds(Long id, InterviewRole role) {
-        return timeSlotUserJpaRepository.findMyTimeSlotIds(id, role);
+    public List<Long> findMyTimeSlotIds(Long userId, InterviewRole role) {
+        return queryFactory
+                .select(timeSlotUser.timeSlot.id)
+                .from(timeSlotUser)
+                .where(
+                        timeSlotUser.user.id.eq(userId),
+                        timeSlotUser.role.eq(role)
+                )
+                .distinct()
+                .fetch();
     }
 
     @Override
     public List<TimeSlotUser> findAllByTimeSlotIdInWithUser(List<Long> timeSlotIds) {
-        return timeSlotUserJpaRepository.findAllByTimeSlotIdInWithUser(timeSlotIds);
+        return queryFactory
+                .selectFrom(timeSlotUser)
+                .distinct()
+                .join(timeSlotUser.user).fetchJoin()
+                .join(timeSlotUser.timeSlot).fetchJoin()
+                .where(timeSlotUser.timeSlot.id.in(timeSlotIds))
+                .fetch();
+
     }
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserRepositoryImpl.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/interview/timeslotUser/repository/TimeSlotUserRepositoryImpl.java
@@ -36,4 +36,14 @@ public class TimeSlotUserRepositoryImpl implements TimeSlotUserRepository {
                 )
                 .execute();
     }
+
+    @Override
+    public List<Long> findMyTimeSlotIds(Long id, InterviewRole role) {
+        return timeSlotUserJpaRepository.findMyTimeSlotIds(id, role);
+    }
+
+    @Override
+    public List<TimeSlotUser> findAllByTimeSlotIdInWithUser(List<Long> timeSlotIds) {
+        return timeSlotUserJpaRepository.findAllByTimeSlotIdInWithUser(timeSlotIds);
+    }
 }


### PR DESCRIPTION
### ✨ Related Issue

- #171 

---

### 📌 Task Details
- [x] 면접관/안내자로 필터링
- [x] 배정된 모든 면접 스케줄 조회

---

### 💬 Review Requirements (Optional)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 사용자가 자신의 역할에 따라 필터링된 인터뷰 일정을 조회할 수 있는 새로운 일정 조회 기능이 추가되었습니다. 이제 사용자는 개인 인터뷰 시간대를 날짜별로 정리하여 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->