### PR TITLE
✅ Test: 주요 도메인 테스트 코드 추가 #179

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Java CI/CD with Docker and GitHub Actions
 on:
   push:
     branches: [ "main", "develop" ]
-  pull_request:
-    branches: [ "main", "develop" ]
 
 jobs:
   build-docker-image:

--- a/src/main/java/KUSITMS/WITHUS/domain/application/applicationAcquaintance/repository/ApplicationAcquaintanceJpaRepository.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/application/applicationAcquaintance/repository/ApplicationAcquaintanceJpaRepository.java
@@ -2,8 +2,18 @@ package KUSITMS.WITHUS.domain.application.applicationAcquaintance.repository;
 
 import KUSITMS.WITHUS.domain.application.applicationAcquaintance.entity.ApplicationAcquaintance;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ApplicationAcquaintanceJpaRepository extends JpaRepository<ApplicationAcquaintance, Long> {
     boolean existsByApplication_IdAndUser_Id(Long applicationId, Long userId);
-    void deleteByApplication_IdAndUser_Id(Long applicationId, Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from ApplicationAcquaintance acquaintance
+            where acquaintance.application.id = :applicationId
+              and acquaintance.user.id = :userId
+            """)
+    void deleteByApplication_IdAndUser_Id(@Param("applicationId") Long applicationId, @Param("userId") Long userId);
 }

--- a/src/main/java/KUSITMS/WITHUS/domain/recruitment/position/controller/PositionController.java
+++ b/src/main/java/KUSITMS/WITHUS/domain/recruitment/position/controller/PositionController.java
@@ -30,9 +30,9 @@ public class PositionController {
 
     @DeleteMapping("/{positionId}")
     @Operation(summary = "파트 삭제", description = "해당 ID의 파트를 삭제합니다.")
-    public SuccessResponse<String> delete(@PathVariable Long id) {
-        positionService.delete(id);
-        return SuccessResponse.ok("파트 생성에 성공하였습니다.");
+    public SuccessResponse<String> delete(@PathVariable Long positionId) {
+        positionService.delete(positionId);
+        return SuccessResponse.ok("파트 삭제에 성공하였습니다.");
     }
 
     @GetMapping("/recruitment/{recruitmentId}")

--- a/src/main/java/KUSITMS/WITHUS/global/infra/upload/controller/FileController.java
+++ b/src/main/java/KUSITMS/WITHUS/global/infra/upload/controller/FileController.java
@@ -1,19 +1,25 @@
 package KUSITMS.WITHUS.global.infra.upload.controller;
 
 import KUSITMS.WITHUS.global.infra.upload.dto.FileRequestDTO;
+import KUSITMS.WITHUS.global.exception.CustomException;
+import KUSITMS.WITHUS.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,13 +27,23 @@ import java.nio.charset.StandardCharsets;
 @RequestMapping("/api/v1/files")
 public class FileController {
 
+    private static final Set<String> ALLOWED_DOWNLOAD_SCHEMES = Set.of("http", "https");
+
+    @Value("${ncp.storage.endpoint}")
+    private String storageEndpoint;
+
+    @Value("${ncp.storage.bucket-name}")
+    private String bucketName;
+
     @PostMapping("/download")
     @Operation(summary = "파일 다운로드 api", description = "브라우저에서 이미지 다운로드")
     public ResponseEntity<InputStreamResource> downloadImage(
             @RequestBody FileRequestDTO.Download request
             ) {
+        URL imageUrl = parseAllowedDownloadUrl(request.imageUrl());
+
         try {
-            InputStream in = new URL(request.imageUrl()).openStream();
+            InputStream in = imageUrl.openStream();
 
             String encodedFileName = URLEncoder.encode(request.fileName(), StandardCharsets.UTF_8)
                     .replaceAll("\\+", "%20");
@@ -42,6 +58,27 @@ public class FileController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(null);
+        }
+    }
+
+    private URL parseAllowedDownloadUrl(String rawUrl) {
+        try {
+            URL url = new URL(rawUrl);
+            if (!ALLOWED_DOWNLOAD_SCHEMES.contains(url.getProtocol().toLowerCase(Locale.ROOT))) {
+                throw new CustomException(ErrorCode.INVALID_URL);
+            }
+
+            URL endpoint = new URL(storageEndpoint);
+            if (!url.getHost().equals(endpoint.getHost())) {
+                throw new CustomException(ErrorCode.INVALID_URL);
+            }
+
+            if (!url.getPath().startsWith("/" + bucketName + "/")) {
+                throw new CustomException(ErrorCode.INVALID_URL);
+            }
+            return url;
+        } catch (MalformedURLException e) {
+            throw new CustomException(ErrorCode.INVALID_URL);
         }
     }
 }

--- a/src/test/java/KUSITMS/WITHUS/integration/config/MockInfraBeans.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/config/MockInfraBeans.java
@@ -3,12 +3,19 @@ package KUSITMS.WITHUS.integration.config;
 import KUSITMS.WITHUS.global.infra.email.sender.MailSender;
 import KUSITMS.WITHUS.global.infra.sms.SmsSender;
 import KUSITMS.WITHUS.global.infra.upload.uploader.Uploader;
+import KUSITMS.WITHUS.global.util.redis.RefreshTokenCacheUtil;
+import KUSITMS.WITHUS.global.util.redis.VerificationCache;
 import KUSITMS.WITHUS.util.FakeMailSender;
 import KUSITMS.WITHUS.util.FakeSmsSender;
 import KUSITMS.WITHUS.util.FakeUploader;
+import KUSITMS.WITHUS.util.FakeVerificationCacheUtil;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @TestConfiguration
 public class MockInfraBeans {
@@ -30,6 +37,34 @@ public class MockInfraBeans {
     public Uploader uploader() {
         return new FakeUploader();
     }
-}
 
+    @Bean
+    @Primary
+    public VerificationCache verificationCache() {
+        return new FakeVerificationCacheUtil();
+    }
+
+    @Bean
+    @Primary
+    public RefreshTokenCacheUtil refreshTokenCacheUtil() {
+        return new RefreshTokenCacheUtil(null) {
+            private final Map<String, String> store = new ConcurrentHashMap<>();
+
+            @Override
+            public void saveRefreshToken(String email, String refreshToken, Duration ttl) {
+                store.put(email, refreshToken);
+            }
+
+            @Override
+            public String getRefreshToken(String email) {
+                return store.get(email);
+            }
+
+            @Override
+            public void deleteRefreshToken(String email) {
+                store.remove(email);
+            }
+        };
+    }
+}
 

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/application/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/application/application/controller/ApplicationControllerTest.java
@@ -2,6 +2,7 @@ package KUSITMS.WITHUS.integration.domain.application.application.controller;
 
 import KUSITMS.WITHUS.domain.application.application.dto.ApplicationRequestDTO;
 import KUSITMS.WITHUS.domain.application.application.enumerate.AcademicStatus;
+import KUSITMS.WITHUS.domain.application.applicationAnswer.dto.ApplicationAnswerRequestDTO;
 import KUSITMS.WITHUS.domain.application.applicationEvaluator.dto.ApplicationEvaluatorRequestDTO;
 import KUSITMS.WITHUS.domain.application.enumerate.ApplicationStatus;
 import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationScaleType;
@@ -9,6 +10,9 @@ import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationT
 import KUSITMS.WITHUS.domain.organization.organization.dto.OrganizationRequestDTO;
 import KUSITMS.WITHUS.domain.organization.organization.repository.OrganizationRepository;
 import KUSITMS.WITHUS.domain.organization.organization.service.OrganizationService;
+import KUSITMS.WITHUS.domain.recruitment.availableTimeRange.dto.AvailableTimeRangeRequestDTO;
+import KUSITMS.WITHUS.domain.recruitment.documentQuestion.dto.DocumentQuestionRequestDTO;
+import KUSITMS.WITHUS.domain.recruitment.documentQuestion.enumerate.QuestionType;
 import KUSITMS.WITHUS.domain.recruitment.recruitment.dto.RecruitmentRequestDTO;
 import KUSITMS.WITHUS.domain.recruitment.recruitment.repository.RecruitmentRepository;
 import KUSITMS.WITHUS.domain.user.user.entity.User;
@@ -19,6 +23,8 @@ import KUSITMS.WITHUS.integration.config.MockInfraBeans;
 import KUSITMS.WITHUS.integration.util.TestAuthHelper;
 import KUSITMS.WITHUS.integration.util.TestHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,8 +42,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -59,6 +67,7 @@ class ApplicationControllerTest {
     @Autowired private OrganizationService organizationService;
     @Autowired private OrganizationRepository organizationRepository;
     @Autowired private RecruitmentRepository recruitmentRepository;
+    @Autowired private EntityManager entityManager;
 
     private final String testMail = "testMail@gmail.com";
     private Long savedOrganizationId;
@@ -253,6 +262,93 @@ class ApplicationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.name").value("홍길동"))
                 .andExpect(jsonPath("$.result.email").value("user@example.com"));
+    }
+
+    @Test
+    @DisplayName("지원서 생성 성공 - 공통 질문과 역할별 질문 답변 저장")
+    void createApplicationSavesCommonAndRoleQuestionAnswers() throws Exception {
+        Long backendRoleId = testHelper.createOrganizationRole(savedOrganizationId, "백엔드", accessToken);
+        Long designRoleId = testHelper.createOrganizationRole(savedOrganizationId, "디자인", accessToken);
+        var recruitmentRequest = new RecruitmentRequestDTO.Upsert(
+                null, "질문 답변 저장 공고", "설명",
+                List.of(backendRoleId, designRoleId),
+                List.of(
+                        new DocumentQuestionRequestDTO.Create("공통 자기소개", "", QuestionType.TEXT, true, 500, true, null, null, null, 1),
+                        new DocumentQuestionRequestDTO.Create("백엔드 경험", "", QuestionType.TEXT, true, 500, true, null, null, backendRoleId, 2),
+                        new DocumentQuestionRequestDTO.Create("디자인 경험", "", QuestionType.TEXT, true, 500, true, null, null, designRoleId, 3)
+                ),
+                LocalDate.now().plusDays(5), true,
+                LocalDate.now().plusDays(10), LocalDate.now().plusDays(15),
+                (short) 30, savedOrganizationId,
+                false, true, true, true, true, false, true,
+                EvaluationScaleType.SCORE, EvaluationScaleType.SCORE,
+                List.of(), List.of(),
+                true,
+                List.of(new AvailableTimeRangeRequestDTO(LocalDate.now().plusDays(1), LocalTime.of(10, 0), LocalTime.of(18, 0)))
+        );
+
+        String recruitmentResponse = mockMvc.perform(post("/api/v1/recruitments/publish")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(recruitmentRequest)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long recruitmentId = ((Number) JsonPath.read(recruitmentResponse, "$.result.recruitmentId")).longValue();
+        entityManager.flush();
+        entityManager.clear();
+
+        Long commonQuestionId = recruitmentRepository.getById(recruitmentId).getQuestions().stream()
+                .filter(question -> question.getTitle().equals("공통 자기소개"))
+                .findFirst()
+                .orElseThrow()
+                .getId();
+        Long backendQuestionId = recruitmentRepository.getById(recruitmentId).getQuestions().stream()
+                .filter(question -> question.getTitle().equals("백엔드 경험"))
+                .findFirst()
+                .orElseThrow()
+                .getId();
+
+        ApplicationRequestDTO.Create requestDto = new ApplicationRequestDTO.Create(
+                "답변지원자", "answer@example.com", "01012341234", Gender.MALE,
+                "상명대학교", "컴퓨터공학과", AcademicStatus.ENROLLED,
+                LocalDate.of(2001, 1, 1), "서울시",
+                recruitmentId,
+                backendRoleId,
+                List.of(
+                        new ApplicationAnswerRequestDTO(commonQuestionId, "공통 답변입니다.", null),
+                        new ApplicationAnswerRequestDTO(backendQuestionId, "백엔드 답변입니다.", null)
+                ),
+                List.of(LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(10, 0)))
+        );
+
+        MockMultipartFile jsonPart = new MockMultipartFile(
+                "request", "", "application/json", objectMapper.writeValueAsBytes(requestDto)
+        );
+
+        String applicationResponse = mockMvc.perform(multipart("/api/v1/applications")
+                        .file(jsonPart)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.organizationRoleName").value("백엔드"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long applicationId = ((Number) JsonPath.read(applicationResponse, "$.result.id")).longValue();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<String> savedAnswerTexts = entityManager.createQuery(
+                        "select answer.answerText from ApplicationAnswer answer " +
+                                "where answer.application.id = :applicationId order by answer.id",
+                        String.class
+                )
+                .setParameter("applicationId", applicationId)
+                .getResultList();
+
+        assertThat(savedAnswerTexts).containsExactly("공통 답변입니다.", "백엔드 답변입니다.");
     }
 
     @Test

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/application/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/application/application/controller/ApplicationControllerTest.java
@@ -84,6 +84,39 @@ class ApplicationControllerTest {
         userRepository.save(user);
     }
 
+    private void addRolesToRecruitment(Long recruitmentId, String title, List<Long> organizationRoleIds) throws Exception {
+        var updateRequest = new RecruitmentRequestDTO.Update(
+                title, "설명", null,
+                organizationRoleIds,
+                LocalDate.now().plusDays(5), true, LocalDate.now().plusDays(10), LocalDate.now().plusDays(15),
+                (short) 30, false, true, true, true, true, false, true, false,
+                EvaluationScaleType.SCORE, EvaluationScaleType.SCORE,
+                List.of(), List.of(), true, List.of()
+        );
+
+        mockMvc.perform(put("/api/v1/recruitments/" + recruitmentId)
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk());
+    }
+
+    private MockMultipartFile applicationRequestPart(Long recruitmentId, Long organizationRoleId, String email) throws Exception {
+        ApplicationRequestDTO.Create requestDto = new ApplicationRequestDTO.Create(
+                "역할검증", email, "01012341234", Gender.MALE,
+                "상명대학교", "컴퓨터공학과", AcademicStatus.ENROLLED,
+                LocalDate.of(2001, 1, 1), "서울시 도봉구 56로 501",
+                recruitmentId,
+                organizationRoleId,
+                List.of(),
+                List.of(LocalDateTime.of(2025, 4, 22, 10, 0))
+        );
+
+        return new MockMultipartFile(
+                "request", "", "application/json", objectMapper.writeValueAsBytes(requestDto)
+        );
+    }
+
     @Test
     @DisplayName("지원서 생성 성공")
     void createApplicationSuccess() throws Exception {
@@ -154,6 +187,36 @@ class ApplicationControllerTest {
                         .header("Authorization", accessToken)
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isPreconditionFailed());
+    }
+
+    @Test
+    @DisplayName("지원서 생성 실패 - 공고에 포함되지 않은 조직 역할")
+    void createApplicationWithRoleNotIncludedInRecruitmentShouldReturnNotFound() throws Exception {
+        Long recruitmentId = testHelper.createRecruitment("역할 검증 공고", savedOrganizationId, accessToken);
+        Long backendRoleId = testHelper.createOrganizationRole(savedOrganizationId, "백엔드", accessToken);
+        Long frontendRoleId = testHelper.createOrganizationRole(savedOrganizationId, "프론트엔드", accessToken);
+        addRolesToRecruitment(recruitmentId, "역할 검증 공고", List.of(backendRoleId));
+
+        mockMvc.perform(multipart("/api/v1/applications")
+                        .file(applicationRequestPart(recruitmentId, frontendRoleId, "not-included-role@example.com"))
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("지원서 생성 실패 - 다른 조직의 역할")
+    void createApplicationWithOtherOrganizationRoleShouldReturnNotFound() throws Exception {
+        Long recruitmentId = testHelper.createRecruitment("다른 조직 역할 검증 공고", savedOrganizationId, accessToken);
+        Long backendRoleId = testHelper.createOrganizationRole(savedOrganizationId, "백엔드", accessToken);
+        addRolesToRecruitment(recruitmentId, "다른 조직 역할 검증 공고", List.of(backendRoleId));
+
+        Long otherOrganizationId = organizationService.create(new OrganizationRequestDTO.Create("다른 테스트 조직")).id();
+        Long otherOrganizationRoleId = testHelper.createOrganizationRole(otherOrganizationId, "디자인", accessToken);
+
+        mockMvc.perform(multipart("/api/v1/applications")
+                        .file(applicationRequestPart(recruitmentId, otherOrganizationRoleId, "other-org-role@example.com"))
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/application/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/application/application/controller/ApplicationControllerTest.java
@@ -391,7 +391,20 @@ class ApplicationControllerTest {
         mockMvc.perform(patch("/api/v1/applications/" + appId + "/acquaintance")
                         .header("Authorization", accessToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.acquainted").isBoolean());
+                .andExpect(jsonPath("$.result.acquainted").value(true));
+        entityManager.flush();
+        entityManager.clear();
+
+        mockMvc.perform(get("/api/v1/applications/" + appId)
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.acquaintanceCount").value(1))
+                .andExpect(jsonPath("$.result.acquaintances[0].name").value("테스트유저"));
+
+        mockMvc.perform(patch("/api/v1/applications/" + appId + "/acquaintance")
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.acquainted").value(false));
     }
 
     @Test

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/application/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/application/application/controller/ApplicationControllerTest.java
@@ -405,6 +405,13 @@ class ApplicationControllerTest {
                         .header("Authorization", accessToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.acquainted").value(false));
+        entityManager.flush();
+        entityManager.clear();
+
+        mockMvc.perform(get("/api/v1/applications/" + appId)
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.acquaintanceCount").value(0));
     }
 
     @Test

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/application/comment/controller/CommentControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/application/comment/controller/CommentControllerTest.java
@@ -1,0 +1,189 @@
+package KUSITMS.WITHUS.integration.domain.application.comment.controller;
+
+import KUSITMS.WITHUS.domain.application.comment.dto.CommentRequestDTO;
+import KUSITMS.WITHUS.domain.application.comment.enumerate.CommentType;
+import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationScaleType;
+import KUSITMS.WITHUS.domain.organization.organization.dto.OrganizationRequestDTO;
+import KUSITMS.WITHUS.domain.organization.organization.service.OrganizationService;
+import KUSITMS.WITHUS.domain.recruitment.availableTimeRange.dto.AvailableTimeRangeRequestDTO;
+import KUSITMS.WITHUS.domain.recruitment.recruitment.dto.RecruitmentRequestDTO;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import KUSITMS.WITHUS.integration.config.MockInfraBeans;
+import KUSITMS.WITHUS.integration.util.TestAuthHelper;
+import KUSITMS.WITHUS.integration.util.TestHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(MockInfraBeans.class)
+class CommentControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BCryptPasswordEncoder encoder;
+    @Autowired private OrganizationService organizationService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private TestAuthHelper testAuthHelper;
+    @Autowired private TestHelper testHelper;
+
+    private Long organizationId;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        organizationId = organizationService.create(new OrganizationRequestDTO.Create("코멘트 테스트 조직")).id();
+        createUser("코멘트작성자", "commenter@example.com", "01000003333");
+        accessToken = testAuthHelper.loginAndGetAccessToken("commenter@example.com", "password1!");
+    }
+
+    @Test
+    @DisplayName("지원서 코멘트 생성, 수정, 삭제 성공")
+    void createUpdateAndDeleteCommentSuccess() throws Exception {
+        Long applicationId = createApplication();
+        Long commentId = createComment(applicationId, accessToken, "서류 검토 필요");
+
+        var updateRequest = new CommentRequestDTO.Update("서류 검토 완료");
+
+        mockMvc.perform(put("/api/v1/applications/" + applicationId + "/comments/" + commentId)
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.content").value("서류 검토 완료"))
+                .andExpect(jsonPath("$.result.type").value("DOCUMENT"))
+                .andExpect(jsonPath("$.result.userName").value("코멘트작성자"));
+
+        mockMvc.perform(delete("/api/v1/applications/" + applicationId + "/comments/" + commentId)
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 작성한 코멘트는 수정할 수 없다")
+    void updateCommentForbiddenWhenNotOwner() throws Exception {
+        Long applicationId = createApplication();
+        Long commentId = createComment(applicationId, accessToken, "작성자만 수정 가능");
+        createUser("다른작성자", "other-commenter@example.com", "01000004444");
+        String otherAccessToken = testAuthHelper.loginAndGetAccessToken("other-commenter@example.com", "password1!");
+
+        var updateRequest = new CommentRequestDTO.Update("타인이 수정 시도");
+
+        mockMvc.perform(put("/api/v1/applications/" + applicationId + "/comments/" + commentId)
+                        .header("Authorization", otherAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    private Long createComment(Long applicationId, String token, String content) throws Exception {
+        var request = new CommentRequestDTO.Create(content, CommentType.DOCUMENT);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/applications/" + applicationId + "/comments")
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.content").value(content))
+                .andExpect(jsonPath("$.result.type").value("DOCUMENT"))
+                .andExpect(jsonPath("$.result.user.name").value("코멘트작성자"))
+                .andReturn();
+
+        return ((Number) JsonPath.read(result.getResponse().getContentAsString(), "$.result.id")).longValue();
+    }
+
+    private Long createApplication() throws Exception {
+        Long roleId = testHelper.createOrganizationRole(organizationId, "백엔드", accessToken);
+        Long recruitmentId = createRecruitment(roleId);
+        return testHelper.createApplication(
+                accessToken,
+                recruitmentId,
+                roleId,
+                "코멘트지원자",
+                "comment-applicant@example.com"
+        );
+    }
+
+    private Long createRecruitment(Long roleId) throws Exception {
+        RecruitmentRequestDTO.Upsert request = new RecruitmentRequestDTO.Upsert(
+                null,
+                "코멘트 테스트 공고",
+                "설명",
+                List.of(roleId),
+                List.of(),
+                LocalDate.now().plusDays(5),
+                true,
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(15),
+                (short) 30,
+                organizationId,
+                false,
+                true,
+                true,
+                true,
+                true,
+                false,
+                true,
+                EvaluationScaleType.SCORE,
+                EvaluationScaleType.SCORE,
+                List.of(),
+                List.of(),
+                true,
+                List.of(new AvailableTimeRangeRequestDTO(
+                        LocalDate.now().plusDays(1),
+                        LocalTime.of(10, 0),
+                        LocalTime.of(18, 0)
+                ))
+        );
+
+        MvcResult result = mockMvc.perform(post("/api/v1/recruitments/publish")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return ((Number) JsonPath.read(result.getResponse().getContentAsString(), "$.result.recruitmentId")).longValue();
+    }
+
+    private void createUser(String name, String email, String phoneNumber) {
+        User user = User.builder()
+                .name(name)
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .role(Role.ADMIN)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .password(encoder.encode("password1!"))
+                .build();
+        userRepository.save(user);
+    }
+}

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/evaluation/evaluation/controller/EvaluationControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/evaluation/evaluation/controller/EvaluationControllerTest.java
@@ -34,8 +34,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -84,7 +88,88 @@ class EvaluationControllerTest {
     @Test
     @DisplayName("지원서 평가 등록 성공")
     void evaluateApplicationSuccess() throws Exception {
+        EvaluationTarget target = createEvaluationTarget(List.of("성실성"));
+
+        EvaluationRequestDTO.Create request = new EvaluationRequestDTO.Create(
+                target.applicationId(),
+                target.criteriaIdsByContent().get("성실성"),
+                8
+        );
+
+        mockMvc.perform(post("/api/v1/evaluations")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.score").value(8))
+                .andExpect(jsonPath("$.result.criteria.content").value("성실성"))
+                .andExpect(jsonPath("$.result.user.name").value("평가자"));
+    }
+
+    @Test
+    @DisplayName("같은 평가자가 동일 지원서와 동일 기준에 중복 평가하면 실패")
+    void evaluateApplicationDuplicateFail() throws Exception {
+        EvaluationTarget target = createEvaluationTarget(List.of("성실성"));
+        EvaluationRequestDTO.Create request = new EvaluationRequestDTO.Create(
+                target.applicationId(),
+                target.criteriaIdsByContent().get("성실성"),
+                8
+        );
+
+        mockMvc.perform(post("/api/v1/evaluations")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/evaluations")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("EVALUATION400"));
+    }
+
+    @Test
+    @DisplayName("지원서 평가 벌크 등록 성공")
+    void bulkEvaluateApplicationSuccess() throws Exception {
+        EvaluationTarget target = createEvaluationTarget(List.of("성실성", "전문성"));
+
+        EvaluationRequestDTO.BulkCreate request = new EvaluationRequestDTO.BulkCreate(
+                target.applicationId(),
+                List.of(
+                        new EvaluationRequestDTO.BulkCreate.EvaluationItem(
+                                target.criteriaIdsByContent().get("성실성"),
+                                7
+                        ),
+                        new EvaluationRequestDTO.BulkCreate.EvaluationItem(
+                                target.criteriaIdsByContent().get("전문성"),
+                                9
+                        )
+                )
+        );
+
+        mockMvc.perform(post("/api/v1/evaluations/bulk")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result", hasSize(2)))
+                .andExpect(jsonPath("$.result[*].score", containsInAnyOrder(7, 9)))
+                .andExpect(jsonPath("$.result[*].criteria.content", containsInAnyOrder("성실성", "전문성")))
+                .andExpect(jsonPath("$.result[*].user.name", containsInAnyOrder("평가자", "평가자")));
+    }
+
+    private EvaluationTarget createEvaluationTarget(List<String> criteriaContents) throws Exception {
         Long backendRoleId = testHelper.createOrganizationRole(savedOrganizationId, "백엔드", accessToken);
+        List<EvaluationCriteriaRequestDTO.Create> criteriaRequests = criteriaContents.stream()
+                .map(content -> new EvaluationCriteriaRequestDTO.Create(
+                        content,
+                        content + " 설명",
+                        EvaluationType.DOCUMENT,
+                        backendRoleId
+                ))
+                .toList();
         RecruitmentRequestDTO.Upsert recruitmentRequest = new RecruitmentRequestDTO.Upsert(
                 null, "평가 테스트 공고", "설명",
                 List.of(backendRoleId),
@@ -94,7 +179,7 @@ class EvaluationControllerTest {
                 (short) 30, savedOrganizationId,
                 false, true, true, true, true, false, true,
                 EvaluationScaleType.SCORE, EvaluationScaleType.SCORE,
-                List.of(new EvaluationCriteriaRequestDTO.Create("성실성", "꾸준히 참여할 수 있는지", EvaluationType.DOCUMENT, backendRoleId)),
+                criteriaRequests,
                 List.of(),
                 true,
                 List.of(new AvailableTimeRangeRequestDTO(LocalDate.now().plusDays(1), LocalTime.of(10, 0), LocalTime.of(18, 0)))
@@ -112,11 +197,9 @@ class EvaluationControllerTest {
         entityManager.flush();
         entityManager.clear();
 
-        Long criteriaId = recruitmentRepository.getById(recruitmentId).getEvaluationCriteriaList().stream()
-                .filter(criteria -> criteria.getContent().equals("성실성"))
-                .findFirst()
-                .orElseThrow()
-                .getId();
+        Map<String, Long> criteriaIdsByContent = new LinkedHashMap<>();
+        recruitmentRepository.getById(recruitmentId).getEvaluationCriteriaList()
+                .forEach(criteria -> criteriaIdsByContent.put(criteria.getContent(), criteria.getId()));
         Long applicationId = testHelper.createApplication(
                 accessToken,
                 recruitmentId,
@@ -125,15 +208,9 @@ class EvaluationControllerTest {
                 "evaluation-applicant@example.com"
         );
 
-        EvaluationRequestDTO.Create request = new EvaluationRequestDTO.Create(applicationId, criteriaId, 8);
+        return new EvaluationTarget(applicationId, criteriaIdsByContent);
+    }
 
-        mockMvc.perform(post("/api/v1/evaluations")
-                        .header("Authorization", accessToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.score").value(8))
-                .andExpect(jsonPath("$.result.criteria.content").value("성실성"))
-                .andExpect(jsonPath("$.result.user.name").value("평가자"));
+    private record EvaluationTarget(Long applicationId, Map<String, Long> criteriaIdsByContent) {
     }
 }

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/evaluation/evaluation/controller/EvaluationControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/evaluation/evaluation/controller/EvaluationControllerTest.java
@@ -1,0 +1,139 @@
+package KUSITMS.WITHUS.integration.domain.evaluation.evaluation.controller;
+
+import KUSITMS.WITHUS.domain.evaluation.evaluation.dto.EvaluationRequestDTO;
+import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.dto.EvaluationCriteriaRequestDTO;
+import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationScaleType;
+import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationType;
+import KUSITMS.WITHUS.domain.organization.organization.dto.OrganizationRequestDTO;
+import KUSITMS.WITHUS.domain.organization.organization.service.OrganizationService;
+import KUSITMS.WITHUS.domain.recruitment.availableTimeRange.dto.AvailableTimeRangeRequestDTO;
+import KUSITMS.WITHUS.domain.recruitment.recruitment.dto.RecruitmentRequestDTO;
+import KUSITMS.WITHUS.domain.recruitment.recruitment.repository.RecruitmentRepository;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import KUSITMS.WITHUS.integration.config.MockInfraBeans;
+import KUSITMS.WITHUS.integration.util.TestAuthHelper;
+import KUSITMS.WITHUS.integration.util.TestHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(MockInfraBeans.class)
+class EvaluationControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BCryptPasswordEncoder encoder;
+    @Autowired private TestAuthHelper testAuthHelper;
+    @Autowired private TestHelper testHelper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private OrganizationService organizationService;
+    @Autowired private RecruitmentRepository recruitmentRepository;
+    @Autowired private EntityManager entityManager;
+
+    private final String testMail = "evaluation-test@gmail.com";
+    private Long savedOrganizationId;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        savedOrganizationId = organizationService.create(new OrganizationRequestDTO.Create("평가 테스트 조직")).id();
+        createTestUser();
+        accessToken = testAuthHelper.loginAndGetAccessToken(testMail, "password1!");
+    }
+
+    private void createTestUser() {
+        User user = User.builder()
+                .name("평가자")
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .role(Role.ADMIN)
+                .email(testMail)
+                .phoneNumber("01000002222")
+                .password(encoder.encode("password1!"))
+                .build();
+        userRepository.save(user);
+    }
+
+    @Test
+    @DisplayName("지원서 평가 등록 성공")
+    void evaluateApplicationSuccess() throws Exception {
+        Long backendRoleId = testHelper.createOrganizationRole(savedOrganizationId, "백엔드", accessToken);
+        RecruitmentRequestDTO.Upsert recruitmentRequest = new RecruitmentRequestDTO.Upsert(
+                null, "평가 테스트 공고", "설명",
+                List.of(backendRoleId),
+                List.of(),
+                LocalDate.now().plusDays(5), true,
+                LocalDate.now().plusDays(10), LocalDate.now().plusDays(15),
+                (short) 30, savedOrganizationId,
+                false, true, true, true, true, false, true,
+                EvaluationScaleType.SCORE, EvaluationScaleType.SCORE,
+                List.of(new EvaluationCriteriaRequestDTO.Create("성실성", "꾸준히 참여할 수 있는지", EvaluationType.DOCUMENT, backendRoleId)),
+                List.of(),
+                true,
+                List.of(new AvailableTimeRangeRequestDTO(LocalDate.now().plusDays(1), LocalTime.of(10, 0), LocalTime.of(18, 0)))
+        );
+
+        String recruitmentResponse = mockMvc.perform(post("/api/v1/recruitments/publish")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(recruitmentRequest)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long recruitmentId = ((Number) JsonPath.read(recruitmentResponse, "$.result.recruitmentId")).longValue();
+        entityManager.flush();
+        entityManager.clear();
+
+        Long criteriaId = recruitmentRepository.getById(recruitmentId).getEvaluationCriteriaList().stream()
+                .filter(criteria -> criteria.getContent().equals("성실성"))
+                .findFirst()
+                .orElseThrow()
+                .getId();
+        Long applicationId = testHelper.createApplication(
+                accessToken,
+                recruitmentId,
+                backendRoleId,
+                "평가지원자",
+                "evaluation-applicant@example.com"
+        );
+
+        EvaluationRequestDTO.Create request = new EvaluationRequestDTO.Create(applicationId, criteriaId, 8);
+
+        mockMvc.perform(post("/api/v1/evaluations")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.score").value(8))
+                .andExpect(jsonPath("$.result.criteria.content").value("성실성"))
+                .andExpect(jsonPath("$.result.user.name").value("평가자"));
+    }
+}

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/organization/organization/controller/OrganizationControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/organization/organization/controller/OrganizationControllerTest.java
@@ -1,0 +1,163 @@
+package KUSITMS.WITHUS.integration.domain.organization.organization.controller;
+
+import KUSITMS.WITHUS.domain.organization.organization.dto.OrganizationRequestDTO;
+import KUSITMS.WITHUS.domain.organization.organization.entity.Organization;
+import KUSITMS.WITHUS.domain.organization.organization.repository.OrganizationRepository;
+import KUSITMS.WITHUS.domain.organization.organization.service.OrganizationService;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import KUSITMS.WITHUS.domain.user.userOrganization.entity.UserOrganization;
+import KUSITMS.WITHUS.domain.user.userOrganization.repository.UserOrganizationRepository;
+import KUSITMS.WITHUS.integration.config.MockInfraBeans;
+import KUSITMS.WITHUS.integration.util.TestAuthHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(MockInfraBeans.class)
+class OrganizationControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BCryptPasswordEncoder encoder;
+    @Autowired private OrganizationService organizationService;
+    @Autowired private OrganizationRepository organizationRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserOrganizationRepository userOrganizationRepository;
+    @Autowired private TestAuthHelper testAuthHelper;
+
+    private Long organizationId;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        organizationId = organizationService.create(new OrganizationRequestDTO.Create("테스트 조직")).id();
+        User user = createUser();
+        Organization organization = organizationRepository.getById(organizationId);
+        associateUserWithOrganization(user, organization);
+        accessToken = testAuthHelper.loginAndGetAccessToken("organization-admin@example.com", "password1!");
+    }
+
+    @Test
+    @DisplayName("조직 생성, 단건 조회, 수정, 검색 성공")
+    void createGetUpdateAndSearchOrganizationSuccess() throws Exception {
+        var createRequest = new OrganizationRequestDTO.Create("큐시즘");
+        MvcResult createResult = mockMvc.perform(post("/api/v1/organizations")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.name").value("큐시즘"))
+                .andReturn();
+        Long createdOrganizationId = ((Number) JsonPath.read(
+                createResult.getResponse().getContentAsString(),
+                "$.result.id"
+        )).longValue();
+
+        mockMvc.perform(get("/api/v1/organizations/" + createdOrganizationId)
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(createdOrganizationId))
+                .andExpect(jsonPath("$.result.name").value("큐시즘"));
+
+        var updateRequest = new OrganizationRequestDTO.Update("큐시즘 리뉴얼");
+
+        mockMvc.perform(put("/api/v1/organizations/" + createdOrganizationId)
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(createdOrganizationId))
+                .andExpect(jsonPath("$.result.name").value("큐시즘 리뉴얼"));
+
+        mockMvc.perform(get("/api/v1/organizations/search")
+                        .param("keyword", "큐시즘"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[*].name", hasItem("큐시즘 리뉴얼")));
+    }
+
+    @Test
+    @DisplayName("조직 소속 사용자는 초대 코드를 생성하고 코드로 조직을 조회할 수 있다")
+    void generateInviteCodeAndExchangeSuccess() throws Exception {
+        MvcResult inviteResult = mockMvc.perform(get("/api/v1/organizations/" + organizationId + "/code")
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(organizationId))
+                .andExpect(jsonPath("$.result.name").value("테스트 조직"))
+                .andReturn();
+        String inviteCode = JsonPath.read(inviteResult.getResponse().getContentAsString(), "$.result.inviteCode");
+
+        assertThat(inviteCode).isNotBlank();
+
+        mockMvc.perform(get("/api/v1/organizations/inviteCode/exchange")
+                        .param("inviteCode", inviteCode))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(organizationId))
+                .andExpect(jsonPath("$.result.name").value("테스트 조직"));
+
+        mockMvc.perform(get("/api/v1/organizations/" + organizationId + "/code")
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.inviteCode").value(inviteCode));
+    }
+
+    @Test
+    @DisplayName("조직에 속하지 않은 사용자는 초대 코드를 조회할 수 없다")
+    void generateInviteCodeForbiddenWhenUserIsNotInOrganization() throws Exception {
+        Long otherOrganizationId = organizationService.create(new OrganizationRequestDTO.Create("다른 조직")).id();
+
+        mockMvc.perform(get("/api/v1/organizations/" + otherOrganizationId + "/code")
+                        .header("Authorization", accessToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    private User createUser() {
+        User user = User.builder()
+                .name("조직관리자")
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .role(Role.ADMIN)
+                .email("organization-admin@example.com")
+                .phoneNumber("01011112222")
+                .password(encoder.encode("password1!"))
+                .build();
+        return userRepository.save(user);
+    }
+
+    private void associateUserWithOrganization(User user, Organization organization) {
+        UserOrganization userOrganization = UserOrganization.builder()
+                .user(user)
+                .organization(organization)
+                .build();
+        user.addUserOrganization(userOrganization);
+        organization.addUserOrganization(userOrganization);
+        userOrganizationRepository.save(userOrganization);
+    }
+}

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/organization/organizationRole/controller/OrganizationRoleControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/organization/organizationRole/controller/OrganizationRoleControllerTest.java
@@ -1,0 +1,182 @@
+package KUSITMS.WITHUS.integration.domain.organization.organizationRole.controller;
+
+import KUSITMS.WITHUS.domain.organization.organization.dto.OrganizationRequestDTO;
+import KUSITMS.WITHUS.domain.organization.organization.service.OrganizationService;
+import KUSITMS.WITHUS.domain.organization.organizationRole.dto.OrganizationRoleRequestDTO;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import KUSITMS.WITHUS.integration.config.MockInfraBeans;
+import KUSITMS.WITHUS.integration.util.TestAuthHelper;
+import KUSITMS.WITHUS.integration.util.TestHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(MockInfraBeans.class)
+class OrganizationRoleControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BCryptPasswordEncoder encoder;
+    @Autowired private OrganizationService organizationService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private TestAuthHelper testAuthHelper;
+    @Autowired private TestHelper testHelper;
+
+    private Long organizationId;
+    private Long targetUserId;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        organizationId = organizationService.create(new OrganizationRequestDTO.Create("테스트 조직")).id();
+        createUser("관리자", "admin@example.com", "01000001111", Role.ADMIN);
+        targetUserId = createUser("운영진", "staff@example.com", "01000002222", Role.USER);
+        accessToken = testAuthHelper.loginAndGetAccessToken("admin@example.com", "password1!");
+    }
+
+    @Test
+    @DisplayName("조직 역할 생성 및 조회 성공")
+    void createAndGetOrganizationRolesSuccess() throws Exception {
+        Long backendRoleId = testHelper.createOrganizationRole(organizationId, "백엔드", accessToken);
+        Long designRoleId = testHelper.createOrganizationRole(organizationId, "디자인", accessToken);
+
+        mockMvc.perform(get("/api/v1/organizations/" + organizationId + "/roles")
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.totalRoleCount").value(2))
+                .andExpect(jsonPath("$.result.roles[*].id", containsInAnyOrder(
+                        backendRoleId.intValue(),
+                        designRoleId.intValue()
+                )))
+                .andExpect(jsonPath("$.result.roles[*].roleName", containsInAnyOrder("백엔드", "디자인")))
+                .andExpect(jsonPath("$.result.roles[*].assignedUserCount", containsInAnyOrder(0, 0)));
+    }
+
+    @Test
+    @DisplayName("조직 내 중복 역할명 생성 실패")
+    void createOrganizationRoleDuplicateNameFail() throws Exception {
+        testHelper.createOrganizationRole(organizationId, "백엔드", accessToken);
+
+        var request = new OrganizationRoleRequestDTO.Create("백엔드", "#00FF00");
+
+        mockMvc.perform(post("/api/v1/organizations/" + organizationId + "/roles")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("ORGANIZATION_ROLE400"));
+    }
+
+    @Test
+    @DisplayName("운영진에게 조직 내 여러 역할 부여 성공")
+    void assignMultipleRolesToUserSuccess() throws Exception {
+        Long backendRoleId = testHelper.createOrganizationRole(organizationId, "백엔드", accessToken);
+        Long educationRoleId = testHelper.createOrganizationRole(organizationId, "교육기획팀", accessToken);
+        var request = new OrganizationRoleRequestDTO.Assign(targetUserId, List.of(backendRoleId, educationRoleId));
+
+        mockMvc.perform(post("/api/v1/organizations/" + organizationId + "/assign-role")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result", hasSize(2)))
+                .andExpect(jsonPath("$.result[*].userName", containsInAnyOrder("운영진", "운영진")))
+                .andExpect(jsonPath("$.result[*].roleName", containsInAnyOrder("백엔드", "교육기획팀")));
+
+        mockMvc.perform(get("/api/v1/organizations/" + organizationId + "/roles")
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.roles[?(@.roleName == '백엔드')].assignedUserCount").value(1))
+                .andExpect(jsonPath("$.result.roles[?(@.roleName == '교육기획팀')].assignedUserCount").value(1));
+    }
+
+    @Test
+    @DisplayName("운영진 역할 재부여 시 요청에 없는 기존 역할 제거")
+    void reassignUserRolesRemovesMissingRole() throws Exception {
+        Long backendRoleId = testHelper.createOrganizationRole(organizationId, "백엔드", accessToken);
+        Long designRoleId = testHelper.createOrganizationRole(organizationId, "디자인", accessToken);
+
+        assignRoles(targetUserId, List.of(backendRoleId, designRoleId));
+
+        var request = new OrganizationRoleRequestDTO.Assign(targetUserId, List.of(designRoleId));
+
+        mockMvc.perform(post("/api/v1/organizations/" + organizationId + "/assign-role")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result", hasSize(1)))
+                .andExpect(jsonPath("$.result[0].userName").value("운영진"))
+                .andExpect(jsonPath("$.result[0].roleName").value("디자인"));
+
+        mockMvc.perform(get("/api/v1/organizations/" + organizationId + "/roles")
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.roles[?(@.roleName == '백엔드')].assignedUserCount").value(0))
+                .andExpect(jsonPath("$.result.roles[?(@.roleName == '디자인')].assignedUserCount").value(1));
+    }
+
+    @Test
+    @DisplayName("다른 조직 역할을 운영진에게 부여하면 실패")
+    void assignRoleFromOtherOrganizationFail() throws Exception {
+        Long otherOrganizationId = organizationService.create(new OrganizationRequestDTO.Create("다른 조직")).id();
+        Long otherRoleId = testHelper.createOrganizationRole(otherOrganizationId, "대외협력팀", accessToken);
+        var request = new OrganizationRoleRequestDTO.Assign(targetUserId, List.of(otherRoleId));
+
+        mockMvc.perform(post("/api/v1/organizations/" + organizationId + "/assign-role")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("ORGANIZATION_ROLE403"));
+    }
+
+    private Long createUser(String name, String email, String phoneNumber, Role role) {
+        User user = User.builder()
+                .name(name)
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .role(role)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .password(encoder.encode("password1!"))
+                .build();
+        return userRepository.save(user).getId();
+    }
+
+    private void assignRoles(Long userId, List<Long> roleIds) throws Exception {
+        var request = new OrganizationRoleRequestDTO.Assign(userId, roleIds);
+
+        mockMvc.perform(post("/api/v1/organizations/" + organizationId + "/assign-role")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/recruitment/position/controller/PositionControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/recruitment/position/controller/PositionControllerTest.java
@@ -1,0 +1,160 @@
+package KUSITMS.WITHUS.integration.domain.recruitment.position.controller;
+
+import KUSITMS.WITHUS.domain.evaluation.evaluationCriteria.enumerate.EvaluationScaleType;
+import KUSITMS.WITHUS.domain.organization.organization.dto.OrganizationRequestDTO;
+import KUSITMS.WITHUS.domain.organization.organization.service.OrganizationService;
+import KUSITMS.WITHUS.domain.recruitment.availableTimeRange.dto.AvailableTimeRangeRequestDTO;
+import KUSITMS.WITHUS.domain.recruitment.position.dto.PositionRequestDTO;
+import KUSITMS.WITHUS.domain.recruitment.recruitment.dto.RecruitmentRequestDTO;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import KUSITMS.WITHUS.integration.config.MockInfraBeans;
+import KUSITMS.WITHUS.integration.util.TestAuthHelper;
+import KUSITMS.WITHUS.integration.util.TestHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(MockInfraBeans.class)
+class PositionControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BCryptPasswordEncoder encoder;
+    @Autowired private OrganizationService organizationService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private TestAuthHelper testAuthHelper;
+    @Autowired private TestHelper testHelper;
+
+    private Long organizationId;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        organizationId = organizationService.create(new OrganizationRequestDTO.Create("파트 테스트 조직")).id();
+        createUser();
+        accessToken = testAuthHelper.loginAndGetAccessToken("position-admin@example.com", "password1!");
+    }
+
+    @Test
+    @DisplayName("파트 생성 및 삭제 성공")
+    void createAndDeletePositionSuccess() throws Exception {
+        Long recruitmentId = createRecruitment(List.of());
+        var request = new PositionRequestDTO.Create("레거시 파트", recruitmentId);
+
+        MvcResult result = mockMvc.perform(post("/api/v1/positions")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.name").value("레거시 파트"))
+                .andReturn();
+        Long positionId = ((Number) JsonPath.read(result.getResponse().getContentAsString(), "$.result.id")).longValue();
+
+        mockMvc.perform(delete("/api/v1/positions/" + positionId)
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @DisplayName("공고별 파트 조회는 공고에 연결된 조직 역할을 반환한다")
+    void findAllByRecruitmentIdReturnsOrganizationRoles() throws Exception {
+        Long backendRoleId = testHelper.createOrganizationRole(organizationId, "백엔드", accessToken);
+        Long designRoleId = testHelper.createOrganizationRole(organizationId, "디자인", accessToken);
+        Long recruitmentId = createRecruitment(List.of(backendRoleId, designRoleId));
+
+        mockMvc.perform(get("/api/v1/positions/recruitment/" + recruitmentId)
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result", hasSize(2)))
+                .andExpect(jsonPath("$.result[*].id", containsInAnyOrder(
+                        backendRoleId.intValue(),
+                        designRoleId.intValue()
+                )))
+                .andExpect(jsonPath("$.result[*].name", containsInAnyOrder("백엔드", "디자인")));
+    }
+
+    private Long createRecruitment(List<Long> roleIds) throws Exception {
+        RecruitmentRequestDTO.Upsert request = new RecruitmentRequestDTO.Upsert(
+                null,
+                "파트 테스트 공고",
+                "설명",
+                roleIds,
+                List.of(),
+                LocalDate.now().plusDays(5),
+                true,
+                LocalDate.now().plusDays(10),
+                LocalDate.now().plusDays(15),
+                (short) 30,
+                organizationId,
+                false,
+                true,
+                true,
+                true,
+                true,
+                false,
+                true,
+                EvaluationScaleType.SCORE,
+                EvaluationScaleType.SCORE,
+                List.of(),
+                List.of(),
+                true,
+                List.of(new AvailableTimeRangeRequestDTO(
+                        LocalDate.now().plusDays(1),
+                        LocalTime.of(10, 0),
+                        LocalTime.of(18, 0)
+                ))
+        );
+
+        MvcResult result = mockMvc.perform(post("/api/v1/recruitments/publish")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return ((Number) JsonPath.read(result.getResponse().getContentAsString(), "$.result.recruitmentId")).longValue();
+    }
+
+    private void createUser() {
+        User user = User.builder()
+                .name("파트관리자")
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .role(Role.ADMIN)
+                .email("position-admin@example.com")
+                .phoneNumber("01022223333")
+                .password(encoder.encode("password1!"))
+                .build();
+        userRepository.save(user);
+    }
+}

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/recruitment/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/recruitment/recruitment/controller/RecruitmentControllerTest.java
@@ -146,6 +146,47 @@ class RecruitmentControllerTest {
     }
 
     @Test
+    @DisplayName("공고 상세 조회 성공 - 공통 질문과 역할별 질문 포함")
+    void getRecruitmentByIdIncludesCommonAndRoleQuestions() throws Exception {
+        Long backendRoleId = testHelper.createOrganizationRole(savedOrganizationId, "백엔드", accessToken);
+        Long designRoleId = testHelper.createOrganizationRole(savedOrganizationId, "디자인", accessToken);
+        var request = new RecruitmentRequestDTO.Upsert(
+                null, "질문 포함 공고", "설명",
+                List.of(backendRoleId, designRoleId),
+                List.of(
+                        new DocumentQuestionRequestDTO.Create("공통 질문", "", QuestionType.TEXT, true, 500, true, null, null, null, 1),
+                        new DocumentQuestionRequestDTO.Create("백엔드 질문", "", QuestionType.TEXT, true, 500, true, null, null, backendRoleId, 2),
+                        new DocumentQuestionRequestDTO.Create("디자인 질문", "", QuestionType.TEXT, true, 500, true, null, null, designRoleId, 3)
+                ),
+                LocalDate.now().plusDays(5),
+                true, LocalDate.now().plusDays(10), LocalDate.now().plusDays(15),
+                (short) 10, savedOrganizationId,
+                true, true, true, true, true, false, true,
+                EvaluationScaleType.SCORE, EvaluationScaleType.SCORE,
+                List.of(), List.of(),
+                true,
+                List.of(new AvailableTimeRangeRequestDTO(LocalDate.now().plusDays(2), LocalTime.of(10, 0), LocalTime.of(12, 0)))
+        );
+
+        String createResponse = performWithAuth(post("/api/v1/recruitments/publish"), objectMapper.writeValueAsString(request))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long recruitmentId = ((Number) JsonPath.read(createResponse, "$.result.recruitmentId")).longValue();
+
+        mockMvc.perform(get("/api/v1/recruitments/" + recruitmentId)
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.applicationQuestions[0].title").value("공통 질문"))
+                .andExpect(jsonPath("$.result.applicationQuestions[0].organizationRoleName").value("공통"))
+                .andExpect(jsonPath("$.result.applicationQuestions[1].title").value("백엔드 질문"))
+                .andExpect(jsonPath("$.result.applicationQuestions[1].organizationRoleName").value("백엔드"))
+                .andExpect(jsonPath("$.result.applicationQuestions[2].title").value("디자인 질문"))
+                .andExpect(jsonPath("$.result.applicationQuestions[2].organizationRoleName").value("디자인"));
+    }
+
+    @Test
     @DisplayName("공고 삭제 성공")
     void deleteRecruitment() throws Exception {
         mockMvc.perform(delete("/api/v1/recruitments/" + savedRecruitmentId)

--- a/src/test/java/KUSITMS/WITHUS/integration/domain/template/controller/TemplateControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/domain/template/controller/TemplateControllerTest.java
@@ -1,0 +1,176 @@
+package KUSITMS.WITHUS.integration.domain.template.controller;
+
+import KUSITMS.WITHUS.domain.organization.organization.dto.OrganizationRequestDTO;
+import KUSITMS.WITHUS.domain.organization.organization.entity.Organization;
+import KUSITMS.WITHUS.domain.organization.organization.repository.OrganizationRepository;
+import KUSITMS.WITHUS.domain.organization.organization.service.OrganizationService;
+import KUSITMS.WITHUS.domain.template.dto.TemplateRequestDTO;
+import KUSITMS.WITHUS.domain.template.enumerate.Medium;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import KUSITMS.WITHUS.domain.user.userOrganization.entity.UserOrganization;
+import KUSITMS.WITHUS.domain.user.userOrganization.repository.UserOrganizationRepository;
+import KUSITMS.WITHUS.integration.config.MockInfraBeans;
+import KUSITMS.WITHUS.integration.util.TestAuthHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(MockInfraBeans.class)
+class TemplateControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BCryptPasswordEncoder encoder;
+    @Autowired private OrganizationService organizationService;
+    @Autowired private OrganizationRepository organizationRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserOrganizationRepository userOrganizationRepository;
+    @Autowired private TestAuthHelper testAuthHelper;
+
+    private Long organizationId;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        organizationId = organizationService.create(new OrganizationRequestDTO.Create("템플릿 테스트 조직")).id();
+        User user = createUser("템플릿관리자", "template-admin@example.com", "01033334444");
+        associateUserWithOrganization(user, organizationRepository.getById(organizationId));
+        accessToken = testAuthHelper.loginAndGetAccessToken("template-admin@example.com", "password1!");
+    }
+
+    @Test
+    @DisplayName("메일 템플릿 생성, 조회, 목록, 수정, 삭제 성공")
+    void createGetListUpdateAndDeleteTemplateSuccess() throws Exception {
+        Long templateId = createTemplate(accessToken, organizationId, "면접 안내", Medium.MAIL);
+
+        mockMvc.perform(get("/api/v1/templates/" + templateId)
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.name").value("면접 안내"))
+                .andExpect(jsonPath("$.result.subject").value("[WITHUS] 면접 안내"))
+                .andExpect(jsonPath("$.result.medium").value("MAIL"));
+
+        mockMvc.perform(get("/api/v1/templates")
+                        .header("Authorization", accessToken)
+                        .param("medium", "MAIL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[*].name", hasItem("면접 안내")))
+                .andExpect(jsonPath("$.result[*].organizationName", hasItem("템플릿 테스트 조직")));
+
+        var updateRequest = new TemplateRequestDTO.Update(
+                "최종 합격 안내",
+                "[WITHUS] 최종 합격 안내",
+                "최종 합격을 축하합니다.",
+                Medium.MAIL
+        );
+
+        mockMvc.perform(put("/api/v1/templates/" + templateId)
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.name").value("최종 합격 안내"))
+                .andExpect(jsonPath("$.result.subject").value("[WITHUS] 최종 합격 안내"))
+                .andExpect(jsonPath("$.result.body").value("최종 합격을 축하합니다."));
+
+        mockMvc.perform(delete("/api/v1/templates/" + templateId)
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("템플릿이 삭제되었습니다."));
+    }
+
+    @Test
+    @DisplayName("소속되지 않은 조직의 템플릿은 수정할 수 없다")
+    void updateTemplateForbiddenWhenUserIsNotInOrganization() throws Exception {
+        Long templateId = createTemplate(accessToken, organizationId, "불가 템플릿", Medium.SMS);
+
+        Long otherOrganizationId = organizationService.create(new OrganizationRequestDTO.Create("다른 템플릿 조직")).id();
+        User otherUser = createUser("다른관리자", "other-template-admin@example.com", "01033335555");
+        associateUserWithOrganization(otherUser, organizationRepository.getById(otherOrganizationId));
+        String otherAccessToken = testAuthHelper.loginAndGetAccessToken("other-template-admin@example.com", "password1!");
+
+        var updateRequest = new TemplateRequestDTO.Update(
+                "수정 시도",
+                null,
+                "권한 없는 수정",
+                Medium.SMS
+        );
+
+        mockMvc.perform(put("/api/v1/templates/" + templateId)
+                        .header("Authorization", otherAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("TEMPLATE403"));
+    }
+
+    private Long createTemplate(String token, Long orgId, String name, Medium medium) throws Exception {
+        var request = new TemplateRequestDTO.Create(
+                name,
+                orgId,
+                medium == Medium.MAIL ? "[WITHUS] " + name : null,
+                name + " 본문",
+                medium
+        );
+
+        MvcResult result = mockMvc.perform(post("/api/v1/templates")
+                        .header("Authorization", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.name").value(name))
+                .andExpect(jsonPath("$.result.medium").value(medium.name()))
+                .andReturn();
+
+        return ((Number) JsonPath.read(result.getResponse().getContentAsString(), "$.result.id")).longValue();
+    }
+
+    private User createUser(String name, String email, String phoneNumber) {
+        User user = User.builder()
+                .name(name)
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .role(Role.ADMIN)
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .password(encoder.encode("password1!"))
+                .build();
+        return userRepository.save(user);
+    }
+
+    private void associateUserWithOrganization(User user, Organization organization) {
+        UserOrganization userOrganization = UserOrganization.builder()
+                .user(user)
+                .organization(organization)
+                .build();
+        user.addUserOrganization(userOrganization);
+        organization.addUserOrganization(userOrganization);
+        userOrganizationRepository.save(userOrganization);
+    }
+}

--- a/src/test/java/KUSITMS/WITHUS/integration/global/auth/controller/AuthControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/global/auth/controller/AuthControllerTest.java
@@ -1,0 +1,131 @@
+package KUSITMS.WITHUS.integration.global.auth.controller;
+
+import KUSITMS.WITHUS.domain.user.user.dto.UserRequestDTO;
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import KUSITMS.WITHUS.integration.config.MockInfraBeans;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(MockInfraBeans.class)
+class AuthControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BCryptPasswordEncoder encoder;
+    @Autowired private UserRepository userRepository;
+
+    private final String email = "auth-user@example.com";
+    private final String password = "password1!";
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .name("인증유저")
+                .birthDate(LocalDate.of(1995, 1, 1))
+                .role(Role.ADMIN)
+                .email(email)
+                .phoneNumber("01012345678")
+                .password(encoder.encode(password))
+                .build();
+        userRepository.save(user);
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 access token과 refresh token을 헤더로 반환")
+    void loginSuccessReturnsTokens() throws Exception {
+        UserRequestDTO.Login request = new UserRequestDTO.Login(email, password);
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Authorization"))
+                .andExpect(header().exists("Refresh-Token"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.result.name").value("인증유저"))
+                .andExpect(jsonPath("$.result.role").value("ADMIN"));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 불일치")
+    void loginFailWithWrongPassword() throws Exception {
+        UserRequestDTO.Login request = new UserRequestDTO.Login(email, "wrongPassword1!");
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("USER401"));
+    }
+
+    @Test
+    @DisplayName("Refresh Token으로 Access Token 재발급 성공")
+    void reissueAccessTokenSuccess() throws Exception {
+        MvcResult loginResult = login();
+        String refreshToken = loginResult.getResponse().getHeader("Refresh-Token");
+
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .header("Refresh-Token", refreshToken))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Authorization"))
+                .andExpect(header().string("Authorization", org.hamcrest.Matchers.startsWith("Bearer ")));
+    }
+
+    @Test
+    @DisplayName("로그아웃 후 기존 Refresh Token 재발급 실패")
+    void reissueFailAfterLogout() throws Exception {
+        MvcResult loginResult = login();
+        String accessToken = loginResult.getResponse().getHeader("Authorization");
+        String refreshToken = loginResult.getResponse().getHeader("Refresh-Token");
+
+        assertThat(accessToken).startsWith("Bearer ");
+        assertThat(refreshToken).isNotBlank();
+
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .header("Authorization", accessToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .header("Refresh-Token", refreshToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("TOKEN401"));
+    }
+
+    private MvcResult login() throws Exception {
+        UserRequestDTO.Login request = new UserRequestDTO.Login(email, password);
+
+        return mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+}

--- a/src/test/java/KUSITMS/WITHUS/integration/global/infra/upload/controller/FileControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/global/infra/upload/controller/FileControllerTest.java
@@ -1,0 +1,94 @@
+package KUSITMS.WITHUS.integration.global.infra.upload.controller;
+
+import KUSITMS.WITHUS.domain.user.user.entity.User;
+import KUSITMS.WITHUS.domain.user.user.enumerate.Role;
+import KUSITMS.WITHUS.domain.user.user.repository.UserRepository;
+import KUSITMS.WITHUS.global.infra.upload.dto.FileRequestDTO;
+import KUSITMS.WITHUS.integration.config.MockInfraBeans;
+import KUSITMS.WITHUS.integration.util.TestAuthHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(MockInfraBeans.class)
+class FileControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BCryptPasswordEncoder encoder;
+    @Autowired private UserRepository userRepository;
+    @Autowired private TestAuthHelper testAuthHelper;
+
+    @TempDir
+    Path tempDir;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User user = User.builder()
+                .name("파일관리자")
+                .birthDate(LocalDate.of(1990, 1, 1))
+                .role(Role.ADMIN)
+                .email("file-admin@example.com")
+                .phoneNumber("01044445555")
+                .password(encoder.encode("password1!"))
+                .build();
+        userRepository.save(user);
+        accessToken = testAuthHelper.loginAndGetAccessToken("file-admin@example.com", "password1!");
+    }
+
+    @Test
+    @DisplayName("파일 URL 다운로드 성공")
+    void downloadFileSuccess() throws Exception {
+        Path source = tempDir.resolve("source.txt");
+        Files.writeString(source, "download-content");
+        var request = new FileRequestDTO.Download(source.toUri().toURL().toString(), "결과 파일.txt");
+
+        mockMvc.perform(post("/api/v1/files/download")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", "attachment; filename=%EA%B2%B0%EA%B3%BC%20%ED%8C%8C%EC%9D%BC.txt"))
+                .andExpect(content().bytes("download-content".getBytes()));
+    }
+
+    @Test
+    @DisplayName("잘못된 파일 URL 다운로드 실패")
+    void downloadFileFailWithInvalidUrl() throws Exception {
+        var request = new FileRequestDTO.Download("https://invalid.localhost/not-found.png", "not-found.png");
+
+        mockMvc.perform(post("/api/v1/files/download")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isInternalServerError());
+    }
+}

--- a/src/test/java/KUSITMS/WITHUS/integration/global/infra/upload/controller/FileControllerTest.java
+++ b/src/test/java/KUSITMS/WITHUS/integration/global/infra/upload/controller/FileControllerTest.java
@@ -7,6 +7,7 @@ import KUSITMS.WITHUS.global.infra.upload.dto.FileRequestDTO;
 import KUSITMS.WITHUS.integration.config.MockInfraBeans;
 import KUSITMS.WITHUS.integration.util.TestAuthHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,9 +20,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -37,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(MockInfraBeans.class)
+@TestPropertySource(properties = "ncp.storage.endpoint=http://127.0.0.1")
 class FileControllerTest {
 
     @Autowired private MockMvc mockMvc;
@@ -67,28 +71,72 @@ class FileControllerTest {
     @Test
     @DisplayName("파일 URL 다운로드 성공")
     void downloadFileSuccess() throws Exception {
+        HttpServer server = startFileServer("download-content");
+
+        try {
+            var request = new FileRequestDTO.Download("http://127.0.0.1:" + server.getAddress().getPort() + "/dummy-bucket/source.txt", "결과 파일.txt");
+
+            mockMvc.perform(post("/api/v1/files/download")
+                            .header("Authorization", accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string("Content-Disposition", "attachment; filename=%EA%B2%B0%EA%B3%BC%20%ED%8C%8C%EC%9D%BC.txt"))
+                    .andExpect(content().bytes("download-content".getBytes()));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    @DisplayName("로컬 파일 URL 다운로드 실패")
+    void downloadFileFailWithFileScheme() throws Exception {
         Path source = tempDir.resolve("source.txt");
-        Files.writeString(source, "download-content");
-        var request = new FileRequestDTO.Download(source.toUri().toURL().toString(), "결과 파일.txt");
+        Files.writeString(source, "local-file-content");
+        var request = new FileRequestDTO.Download(source.toUri().toURL().toString(), "source.txt");
 
         mockMvc.perform(post("/api/v1/files/download")
                         .header("Authorization", accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(header().string("Content-Disposition", "attachment; filename=%EA%B2%B0%EA%B3%BC%20%ED%8C%8C%EC%9D%BC.txt"))
-                .andExpect(content().bytes("download-content".getBytes()));
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json("""
+                        {
+                          "code": "FILE400",
+                          "message": "잘못된 이미지 URL 형식입니다",
+                          "success": false
+                        }
+                        """));
     }
 
     @Test
-    @DisplayName("잘못된 파일 URL 다운로드 실패")
-    void downloadFileFailWithInvalidUrl() throws Exception {
+    @DisplayName("허용되지 않은 호스트의 파일 URL 다운로드 실패")
+    void downloadFileFailWithDisallowedHost() throws Exception {
         var request = new FileRequestDTO.Download("https://invalid.localhost/not-found.png", "not-found.png");
 
         mockMvc.perform(post("/api/v1/files/download")
                         .header("Authorization", accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json("""
+                        {
+                          "code": "FILE400",
+                          "message": "잘못된 이미지 URL 형식입니다",
+                          "success": false
+                        }
+                        """));
+    }
+
+    private HttpServer startFileServer(String responseBody) throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/dummy-bucket/source.txt", exchange -> {
+            byte[] bytes = responseBody.getBytes();
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        });
+        server.start();
+        return server;
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,7 +21,7 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
 
   jwt:
-    secret: ${TEST_JWT_SECRET}
+    secret: ${TEST_JWT_SECRET:dGVzdC1qd3Qtc2VjcmV0LWtleS1tdXN0LWJlLWxvbmctZW5vdWdo}
 
 ncp:
   storage:


### PR DESCRIPTION
### ✨ Related Issue

- Closes #179

---

### 📌 Task Details
- [x] 지원서 생성, 질문 답변 저장, 역할 검증 회귀 테스트 추가
- [x] 공고 상세 조회의 공통 질문 및 역할별 질문 응답 테스트 추가
- [x] 조직/조직 역할 생성, 조회, 배정, 다중 역할 부여 테스트 추가
- [x] 평가 생성, 중복 평가 실패, 벌크 평가 테스트 추가
- [x] 평가자 배정 및 공고별 평가 대상 지원서 조회 테스트 보강
- [x] 면접 생성, 스케줄 배정, 면접 시간/구성 조회 테스트 확인
- [x] 지인 표시 토글 테스트 보강 및 해제 후 상세 응답 반영 문제 수정
- [x] 인증, 코멘트, 포지션, 템플릿, 파일 다운로드 등 주요 API 회귀 테스트 추가
- [x] 파트 삭제 API path variable 바인딩 오류 수정
- [x] 전체 테스트 실행 및 통과 확인

---

### 💬 Review Requirements (Optional)

- 다중 역할 선택 기능 구현 전에 기존 단일 역할 기반 흐름을 보장하기 위한 회귀 테스트 추가 작업입니다.
- 테스트 작성 중 발견한 지인 표시 해제 반영 문제와 파트 삭제 API 바인딩 오류를 함께 수정했습니다.
- 검증: `./gradlew test` → `BUILD SUCCESSFUL`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 파트 삭제 API의 응답 메시지가 올바르게 표시되도록 수정했습니다.
  * 지원서, 코멘트, 평가, 조직, 템플릿, 인증, 파일 다운로드 등 주요 흐름의 동작과 권한 처리를 강화했습니다.
  * 삭제 및 조회 관련 처리 안정성을 높였습니다.

* **Tests**
  * 신청서, 코멘트, 평가, 조직, 조직 역할, 파트, 공고, 템플릿, 인증, 파일 다운로드에 대한 통합 테스트를 추가했습니다.
  * 토큰 재발급, 권한 거부, 중복 요청, 벌크 처리, 파일 다운로드 응답까지 검증 범위를 넓혔습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->